### PR TITLE
Fix mantid version to 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pyqt=4;
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pyqt=4;
   - source activate test-environment
   - conda config --add channels conda-forge
   #- conda config --add channels mantid

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib pyqt=4;
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pyqt=4;
   - source activate test-environment
   - conda config --add channels conda-forge
   #- conda config --add channels mantid

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib numpy pyqt=4;
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib pyqt=4;
   - source activate test-environment
   - conda config --add channels conda-forge
   #- conda config --add channels mantid

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pylint matplotlib numpy pyqt=4;
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pyqt=4;
   - source activate test-environment
   - conda config --add channels conda-forge
   #- conda config --add channels mantid

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pyqt=4;
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib numpy pyqt=4;
   - source activate test-environment
   - conda config --add channels conda-forge
   #- conda config --add channels mantid

--- a/RefRed/version.py
+++ b/RefRed/version.py
@@ -3,6 +3,6 @@
 # the minor version and change date gets automatically updated on a git commit
 window_title = 'Liquids Reflectometer Reduction - '
 
-version = (2, 50)
+version = (2, 51)
 last_changes = ""
 str_version = ".".join(map(str, version))

--- a/scripts/RefRed
+++ b/scripts/RefRed
@@ -2,4 +2,4 @@
 #
 # Launch Mantidplot using any necessary LD_PRELOAD or software collection behaviour
 #
-QT_API=pyqt start_refred.py
+QT_API=pyqt python start_refred.py

--- a/scripts/start_refred.py
+++ b/scripts/start_refred.py
@@ -9,12 +9,14 @@ import sys
 from PyQt4.QtGui import QApplication, QSplashScreen, QPixmap
 from PyQt4.QtCore import Qt
 
-sys.path.append("/opt/mantidnightly/bin")
+sys.path.insert(0, "/opt/mantid42/bin")
+sys.path.insert(1, "/opt/mantid42/lib")
 
 # if script was run from commandline
 try:
-    if os.path.abspath(__file__).endswith('scripts/RefRed'):
-        sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    if current_directory.endswith('RefRed/scripts'):
+        sys.path.insert(0, os.path.dirname(current_directory))
 except NameError:
     pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 formats = rpm
 
 [bdist_rpm]
-#requires = mantidplot, numpy, python-matplotlib, python-matplolib-qt4
+requires = mantid42, python, python27-numpy, python2-matplotlib, python2-matplolib-qt4
 packager = Jean Bilheux <bilheuxjm@ornl.gov>


### PR DESCRIPTION
This changes the RefRed rpm to depend on Mantid 4.2.

Updated startup script until I could successfully start RefRed on the analysis computer.