### PR TITLE
Issue 16 l rscale factor error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 MANIFEST
 build
 dist
+.vscode/settings.json

--- a/RefRed/interfaces/sf_calculator_interface.py
+++ b/RefRed/interfaces/sf_calculator_interface.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-#@PydevCodeAnalysisIgnore
 
-# Form implementation generated from reading ui file 'designer//sf_calculator_interface.ui'
+# Form implementation generated from reading ui file 'sf_calculator_interface.ui'
 #
-# Created: Fri May 20 10:03:32 2016
-#      by: PyQt4 UI code generator 4.10.1
+# Created by: PyQt4 UI code generator 4.11.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -36,7 +34,7 @@ class Ui_SFCalculatorInterface(object):
         self.scrollArea.setWidgetResizable(True)
         self.scrollArea.setObjectName(_fromUtf8("scrollArea"))
         self.scrollAreaWidgetContents = QtGui.QWidget()
-        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 1183, 918))
+        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 1188, 942))
         self.scrollAreaWidgetContents.setObjectName(_fromUtf8("scrollAreaWidgetContents"))
         self.verticalLayout_2 = QtGui.QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout_2.setObjectName(_fromUtf8("verticalLayout_2"))
@@ -320,6 +318,13 @@ class Ui_SFCalculatorInterface(object):
         self.horizontalLayout_40.addWidget(self.TOFmanualToUnitsValue)
         spacerItem5 = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
         self.horizontalLayout_40.addItem(spacerItem5)
+        self.forceSortByMetaData = QtGui.QPushButton(self.scrollAreaWidgetContents)
+        self.forceSortByMetaData.setWhatsThis(_fromUtf8(""))
+        self.forceSortByMetaData.setFlat(False)
+        self.forceSortByMetaData.setObjectName(_fromUtf8("forceSortByMetaData"))
+        self.horizontalLayout_40.addWidget(self.forceSortByMetaData)
+        spacerItem6 = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        self.horizontalLayout_40.addItem(spacerItem6)
         self.verticalLayout.addLayout(self.horizontalLayout_40)
         self.tableWidget = QtGui.QTableWidget(self.scrollAreaWidgetContents)
         self.tableWidget.setEnabled(False)
@@ -393,8 +398,8 @@ class Ui_SFCalculatorInterface(object):
         self.verticalLayout.addWidget(self.sfFileNamePreview)
         self.horizontalLayout_4 = QtGui.QHBoxLayout()
         self.horizontalLayout_4.setObjectName(_fromUtf8("horizontalLayout_4"))
-        spacerItem6 = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
-        self.horizontalLayout_4.addItem(spacerItem6)
+        spacerItem7 = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        self.horizontalLayout_4.addItem(spacerItem7)
         self.generateSFfileButton = QtGui.QPushButton(self.scrollAreaWidgetContents)
         self.generateSFfileButton.setEnabled(False)
         self.generateSFfileButton.setObjectName(_fromUtf8("generateSFfileButton"))
@@ -409,7 +414,7 @@ class Ui_SFCalculatorInterface(object):
         self.horizontalLayout_5.addWidget(self.scrollArea)
         SFCalculatorInterface.setCentralWidget(self.centralwidget)
         self.menubar = QtGui.QMenuBar(SFCalculatorInterface)
-        self.menubar.setGeometry(QtCore.QRect(0, 0, 1221, 25))
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 1221, 28))
         self.menubar.setObjectName(_fromUtf8("menubar"))
         self.menuFile = QtGui.QMenu(self.menubar)
         self.menuFile.setObjectName(_fromUtf8("menuFile"))
@@ -489,6 +494,7 @@ class Ui_SFCalculatorInterface(object):
         self.TOFmanualToLabel.setText(_translate("SFCalculatorInterface", "to", None))
         self.TOFmanualToValue.setText(_translate("SFCalculatorInterface", "200", None))
         self.TOFmanualToUnitsValue.setText(_translate("SFCalculatorInterface", "ms", None))
+        self.forceSortByMetaData.setText(_translate("SFCalculatorInterface", "sort", None))
         item = self.tableWidget.horizontalHeaderItem(0)
         item.setText(_translate("SFCalculatorInterface", "Run #", None))
         item = self.tableWidget.horizontalHeaderItem(1)
@@ -537,5 +543,5 @@ class Ui_SFCalculatorInterface(object):
         self.actionEdit_Incident_Medium_List.setText(_translate("SFCalculatorInterface", "Edit Incident Medium List ...", None))
         self.clearSFconentFileMenu.setText(_translate("SFCalculatorInterface", "Clear Content SF File", None))
 
-from mplwidgetnolog import MPLWidgetNoLog
 from .mplwidgetxlog import MPLWidgetXLog
+from mplwidgetnolog import MPLWidgetNoLog

--- a/RefRed/sf_calculator/load_and_sort_nxsdata_for_sf_calculator.py
+++ b/RefRed/sf_calculator/load_and_sort_nxsdata_for_sf_calculator.py
@@ -20,7 +20,13 @@ class LoadAndSortNXSDataForSFcalculator(object):
     is_using_si_slits = False
     sf_gui = None
 
-    def __init__(self, list_runs, parent=None, read_options=None, sort_by_metadata=False):
+    def __init__(
+        self,
+        list_runs,
+        parent=None,
+        read_options=None,
+        sort_by_metadata=False,
+    ):
         self.list_runs = list_runs
         self.read_options = read_options
         self.sf_gui = parent

--- a/RefRed/sf_calculator/load_and_sort_nxsdata_for_sf_calculator.py
+++ b/RefRed/sf_calculator/load_and_sort_nxsdata_for_sf_calculator.py
@@ -20,12 +20,14 @@ class LoadAndSortNXSDataForSFcalculator(object):
     is_using_si_slits = False
     sf_gui = None
 
-    def __init__(self, list_runs, parent=None, read_options=None):
+    def __init__(self, list_runs, parent=None, read_options=None, sort_by_metadata=False):
         self.list_runs = list_runs
         self.read_options = read_options
         self.sf_gui = parent
+        self._sort_by_metadata = sort_by_metadata
         self.loadNXSData()
-        self.sortNXSData()
+        if self._sort_by_metadata:
+            self.sortNXSData()
         self.fillTable()
 
     def loadNXSData(self):
@@ -40,7 +42,10 @@ class LoadAndSortNXSDataForSFcalculator(object):
                 if _data is not None:
                     self.list_NXSData.append(_data)
                     self.loaded_list_runs.append(_runs)
-                    self.sortNXSData()
+                    if self._sort_by_metadata:
+                        self.sortNXSData()
+                    else:
+                        self.list_NXSData_sorted = self.list_NXSData
                     self.fillTable()
                     self.sf_gui.update_table(self, False)
                     QtGui.QApplication.processEvents()

--- a/RefRed/sf_calculator/sf_calculator.py
+++ b/RefRed/sf_calculator/sf_calculator.py
@@ -102,6 +102,7 @@ class SFCalculator(QtGui.QMainWindow, Ui_SFCalculatorInterface):
     def initConnections(self):
         self.yt_plot.toolbar.homeClicked.connect(self.homeYtPlot)
         self.yi_plot.toolbar.homeClicked.connect(self.homeYiPlot)
+        self.forceSortByMetaData.clicked.connect(self.forceSrotTableByMetaData)
 
     def initGui(self):
         palette = QtGui.QPalette()

--- a/RefRed/sf_calculator/sf_calculator.py
+++ b/RefRed/sf_calculator/sf_calculator.py
@@ -179,7 +179,8 @@ class SFCalculator(QtGui.QMainWindow, Ui_SFCalculatorInterface):
         _list_runs = np.unique(np.hstack([_old_runs, _new_runs]))
         o_load_and_sort_nxsdata = LoadAndSortNXSDataForSFcalculator(_list_runs,
                                                                     parent=self,
-                                                                    read_options=self.read_options)
+                                                                    read_options=self.read_options,
+                                                                    )
         self.update_table(o_load_and_sort_nxsdata)
         self.is_manual_edit_of_tableWidget = True
 

--- a/RefRed/sf_calculator/sf_calculator.py
+++ b/RefRed/sf_calculator/sf_calculator.py
@@ -132,6 +132,18 @@ class SFCalculator(QtGui.QMainWindow, Ui_SFCalculatorInterface):
         self.yi_plot.canvas.ax.set_ylim([ymin, ymax])
         self.yi_plot.canvas.draw()
 
+    def forceSrotTableByMetaData(self):
+        print("Force sorting table by metadata")
+        self.is_manual_edit_of_tableWidget = False
+        _list_runs = self.loaded_list_of_runs
+        o_load_and_sort_nxsdata = LoadAndSortNXSDataForSFcalculator(_list_runs,
+                                                                    parent=self,
+                                                                    read_options=self.read_options,
+                                                                    sort_by_metadata=True,
+                                                                    )
+        self.update_table(o_load_and_sort_nxsdata)
+        self.is_manual_edit_of_tableWidget = True
+
     def forceTypeToInt(self, array_value, default_value=-1):
         final_array_value = []
         for _value in array_value:

--- a/RefRed/version.py
+++ b/RefRed/version.py
@@ -3,6 +3,6 @@
 # the minor version and change date gets automatically updated on a git commit
 window_title = 'Liquids Reflectometer Reduction - '
 
-version = (2, 52)
+version = (2, 54)
 last_changes = ""
 str_version = ".".join(map(str, version))

--- a/RefRed/version.py
+++ b/RefRed/version.py
@@ -3,6 +3,6 @@
 # the minor version and change date gets automatically updated on a git commit
 window_title = 'Liquids Reflectometer Reduction - '
 
-version = (2, 51)
+version = (2, 52)
 last_changes = ""
 str_version = ".".join(map(str, version))

--- a/designer/sf_calculator_interface.ui
+++ b/designer/sf_calculator_interface.ui
@@ -25,8 +25,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>1183</width>
-         <height>918</height>
+         <width>1188</width>
+         <height>942</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -738,6 +738,32 @@
              </widget>
             </item>
             <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="forceSortByMetaData">
+              <property name="whatsThis">
+               <string extracomment="Sort entries by metadata instead of the default key (run number)"/>
+              </property>
+              <property name="text">
+               <string>sort</string>
+              </property>
+              <property name="flat">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="horizontalSpacer_24">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
@@ -780,15 +806,6 @@
             </attribute>
             <attribute name="verticalHeaderDefaultSectionSize">
              <number>45</number>
-            </attribute>
-            <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="verticalHeaderDefaultSectionSize">
-             <number>45</number>
-            </attribute>
-            <attribute name="horizontalHeaderCascadingSectionResizes">
-             <bool>false</bool>
             </attribute>
             <column>
              <property name="text">
@@ -985,7 +1002,7 @@
      <x>0</x>
      <y>0</y>
      <width>1221</width>
-     <height>25</height>
+     <height>28</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">


### PR DESCRIPTION
This PR made the following changes to the app `scaling_factor_calculator`:

- The default sorting method upon data loading is __by run number__.
![DefaultSortByRunNum](https://user-images.githubusercontent.com/5064852/97895085-4ed9c700-1d01-11eb-8c1a-14cc185cf5a9.png)

- A new button `sort` is added, which will force reload and sort the table by metadata (previous method)
![ForceSortedByMetaData](https://user-images.githubusercontent.com/5064852/97895152-67e27800-1d01-11eb-9712-ce8864f06150.png)

> NOTE:
The motivation behind this PR is that the current sort by metadata is broken, which prevents the app from generating correct scaling factor.
The beamline scientist are using run number to bypass this issue for newer data, which is by the default sorting is switched to __by run number__.
The long term solution would be fixing the metadata-based sorting, but it is beyond the scope of this PR.

> closes #8 