### PR TITLE
Refl 47 config file browser

### DIFF
--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -37,8 +37,8 @@ class LoadingConfiguration(object):
         file_dialog.setViewMode(QtGui.QFileDialog.List)
         if file_dialog.exec_():
             filename = file_dialog.selectedFiles()
-            if isinstance(filename, QtCore.QStringList):
-                filename = filename[-1]
+        if isinstance(filename, QtCore.QStringList):
+            filename = filename[-1]
         QtGui.QApplication.processEvents()
         if not (filename == "") and os.path.isfile(filename):
             self.filename = str(filename)

--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -29,7 +29,6 @@ class LoadingConfiguration(object):
     def run(self):
         _path = self.parent.path_config
         _filter = ("XML (*.xml);; All Files (*.*)")
-        # add changes here
         filename = QtGui.QFileDialog.getOpenFileName(self.parent,
                                                      'Open Configuration File',
                                                      _path,

--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -29,10 +29,16 @@ class LoadingConfiguration(object):
     def run(self):
         _path = self.parent.path_config
         _filter = ("XML (*.xml);; All Files (*.*)")
-        filename = QtGui.QFileDialog.getOpenFileName(self.parent,
-                                                     'Open Configuration File',
-                                                     _path,
-                                                     _filter)
+        filename = ""
+        file_dialog = QtGui.QFileDialog(self.parent,
+                                        'Open Configuration File',
+                                        _path,
+                                        _filter)
+        file_dialog.setViewMode(QtGui.QFileDialog.List)
+        if file_dialog.exec_():
+            filename = file_dialog.selectedFiles()
+            if isinstance(filename, QtCore.QStringList):
+                filename = filename[-1]
         QtGui.QApplication.processEvents()
         if not (filename == ""):
             self.filename = str(filename)

--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -29,6 +29,7 @@ class LoadingConfiguration(object):
     def run(self):
         _path = self.parent.path_config
         _filter = ("XML (*.xml);; All Files (*.*)")
+        # add changes here
         filename = QtGui.QFileDialog.getOpenFileName(self.parent,
                                                      'Open Configuration File',
                                                      _path,

--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -40,7 +40,7 @@ class LoadingConfiguration(object):
             if isinstance(filename, QtCore.QStringList):
                 filename = filename[-1]
         QtGui.QApplication.processEvents()
-        if not (filename == ""):
+        if not (filename == "") and os.path.isfile(filename):
             self.filename = str(filename)
             self.loading()
             message = 'Done!'


### PR DESCRIPTION
To change the view mode to not display additional metadata, the static function from QFileDialog needed to change to a manual dialog setup. This requirement is derived from the ViewMode being an option separate from all other options in the static function and setup. With this change, the configuration file browser should now display without file size or last modified date.