### PR TITLE
Fix app crash during active update of figure

### DIFF
--- a/RefRed/gui_handling/fill_stitching_table.py
+++ b/RefRed/gui_handling/fill_stitching_table.py
@@ -63,7 +63,13 @@ class FillStitchingTable(ParentHandler):
         self.parent.ui.dataStitchingTable.setItem(self._row_index, 1, _auto_item)
 
     def fillTableForManualStitching(self):
-        _widget_manual = QtGui.QDoubleSpinBox()
+        try:
+            # assume PyQt4
+            _widget_manual = QtGui.QDoubleSpinBox()
+        except AttributeError:
+            # assume PyQt5
+            _widget_manual = QtWidgets.QDoubleSpinBox()
+
         _widget_manual.setMinimum(0.0)
         sf_manual = self._lconfig.sf_manual
         _widget_manual.setValue(sf_manual)

--- a/RefRed/interfaces/mplwidgets.py
+++ b/RefRed/interfaces/mplwidgets.py
@@ -288,7 +288,7 @@ class NavigationToolbar(NavigationToolbar2QT):
                 ax.set_yscale('log')
             self.ylog = not self.ylog
 
-            self.canvas.draw()
+            self.canvas.draw_idle()
             self.logtogy.emit(ax.get_yscale())
         else:
             imgs = ax.images + [c for c in ax.collections if c.__class__.__name__ == 'QuadMesh']
@@ -299,7 +299,7 @@ class NavigationToolbar(NavigationToolbar2QT):
                 else:
                     for img in imgs:
                         img.set_norm(LogNorm(norm.vmin, norm.vmax))
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def toggle_xlog(self, *args):
         ax = self.canvas.ax
@@ -311,7 +311,7 @@ class NavigationToolbar(NavigationToolbar2QT):
                 ax.set_xscale('log')
             self.xlog = not self.xlog
 
-            self.canvas.draw()
+            self.canvas.draw_idle()
             self.logtogx.emit(ax.get_xscale())
         else:
             imgs = ax.images + [c for c in ax.collections if c.__class__.__name__ == 'QuadMesh']
@@ -322,7 +322,7 @@ class NavigationToolbar(NavigationToolbar2QT):
                 else:
                     for img in imgs:
                         img.set_norm(LogNorm(norm.vmin, norm.vmax))
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
 
 class MplCanvas(FigureCanvas):
@@ -438,9 +438,9 @@ class MPLWidgetMine(QtWidgets.QWidget):
         Make sure the cursor is reset to it's default when leaving the widget.
         In some cases the zoom cursor does not reset when leaving the plot.
         '''
-        if self.toolbar:
-            QtWidgets.QApplication.restoreOverrideCursor()
-            self.toolbar._lastCursor = None
+        # if self.toolbar:
+        #     QtWidgets.QApplication.restoreOverrideCursor()
+        #     self.toolbar._lastCursor = None
         return QtWidgets.QWidget.leaveEvent(self, event)
 
     def set_config(self, config):
@@ -456,7 +456,7 @@ class MPLWidgetMine(QtWidgets.QWidget):
         Convenience to redraw the graph.
         '''
         if self.canvas.ax.has_data():
-            self.canvas.draw()
+            self.canvas.draw_idle()
 
     def plot(self, *args, **opts):
         '''

--- a/RefRed/plot/display_plots.py
+++ b/RefRed/plot/display_plots.py
@@ -200,7 +200,6 @@ class DisplayPlots(object):
             self.ix_plot_ui.canvas.ax.set_yscale('linear')
 
         if self._data.all_plot_axis.ix_data_interval is None:
-            # self.ix_plot_ui.canvas.draw()
             [xmin, xmax] = self.ix_plot_ui.canvas.ax.xaxis.get_view_interval()
             [ymin, ymax] = self.ix_plot_ui.canvas.ax.yaxis.get_view_interval()
             self._data.all_plot_axis.ix_data_interval = [xmin, xmax, ymin, ymax]
@@ -210,9 +209,8 @@ class DisplayPlots(object):
             [xmin, xmax, ymin, ymax] = self._data.all_plot_axis.ix_view_interval
             self.ix_plot_ui.canvas.ax.set_xlim([xmin, xmax])
             self.ix_plot_ui.canvas.ax.set_ylim([ymin, ymax])
-            # self.ix_plot_ui.canvas.draw()
         
-        # self.ix_plot_ui.canvas.draw()
+        self.ix_plot_ui.canvas.draw_idle()
 
     def get_ycountsdata_of_tof_range_selected(self):
         autotmin = float(self.tofRangeAuto[0])
@@ -259,7 +257,6 @@ class DisplayPlots(object):
             self.yi_plot_ui.canvas.ax.axhline(self.clocking[1], color=colors.CLOCKING_SELECTION_COLOR)
 
         if self._data.all_plot_axis.yi_data_interval is None:
-            # self.yi_plot_ui.canvas.draw()
             [xmin, xmax] = self.yi_plot_ui.canvas.ax.xaxis.get_view_interval()
             [ymin, ymax] = self.yi_plot_ui.canvas.ax.yaxis.get_view_interval()
             self._data.all_plot_axis.yi_data_interval = [xmin, xmax, ymin, ymax]
@@ -270,7 +267,7 @@ class DisplayPlots(object):
             self.yi_plot_ui.canvas.ax.set_xlim([xmin, xmax])
             self.yi_plot_ui.canvas.ax.set_ylim([ymin, ymax])
         
-        # self.yi_plot_ui.canvas.draw()
+        self.yi_plot_ui.canvas.draw_idle()
 
     def plot_it(self):
         _tof_axis = self.fullTofAxis
@@ -284,13 +281,11 @@ class DisplayPlots(object):
         autotmax = float(self.tofRangeAuto[1])
         self.it_plot_ui.canvas.ax.axvline(autotmin, color=colors.TOF_SELECTION_COLOR)
         self.it_plot_ui.canvas.ax.axvline(autotmax, color=colors.TOF_SELECTION_COLOR)
-        # self.it_plot_ui.canvas.draw()
 
         if self._data.all_plot_axis.is_it_ylog:
             self.it_plot_ui.canvas.ax.set_yscale('log')
         else:
             self.it_plot_ui.canvas.ax.set_yscale('linear')
-        # self.it_plot_ui.canvas.draw()
 
         if self._data.all_plot_axis.it_data_interval is None:
             [xmin, xmax] = self.it_plot_ui.canvas.ax.xaxis.get_view_interval()
@@ -303,7 +298,7 @@ class DisplayPlots(object):
             self.it_plot_ui.canvas.ax.set_xlim([xmin, xmax])
             self.it_plot_ui.canvas.ax.set_ylim([ymin, ymax])
 
-        # self.it_plot_ui.canvas.draw()
+        self.it_plot_ui.canvas.draw_idle()
 
     def plot_yt(self):
 
@@ -343,7 +338,6 @@ class DisplayPlots(object):
 
         if self._data.all_plot_axis.yt_data_interval is None:
             self.yt_plot_ui.canvas.ax.set_ylim(0, self.ylim)
-            # self.yt_plot_ui.canvas.draw()
             [xmin, xmax] = self.yt_plot_ui.canvas.ax.xaxis.get_view_interval()
             [ymin, ymax] = self.yt_plot_ui.canvas.ax.yaxis.get_view_interval()
             self._data.all_plot_axis.yt_data_interval = [xmin, xmax, ymin, ymax]
@@ -354,7 +348,7 @@ class DisplayPlots(object):
             self.yt_plot_ui.canvas.ax.set_xlim([xmin, xmax])
             self.yt_plot_ui.canvas.ax.set_ylim([ymin, ymax])
 
-        # self.yt_plot_ui.canvas.draw()
+        self.yt_plot_ui.canvas.draw_idle()
 
     def displayTOFrange(self, tmin, tmax, units):
         parent = self.parent

--- a/RefRed/plot/popup_plot_1d.py
+++ b/RefRed/plot/popup_plot_1d.py
@@ -592,7 +592,8 @@ class PopupPlot1d(QDialog):
         [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_view_interval
         self.ui.plot_pixel_vs_counts.canvas.ax.set_xlim([xmin, xmax])
         self.ui.plot_pixel_vs_counts.canvas.ax.set_ylim([ymin, ymax])
-        #ui_plot1.canvas.draw()
+
+        ui_plot1.canvas.draw_idle()
 
     def update_counts_vs_pixel_plot(self):
         self.ui.plot_counts_vs_pixel.clear()
@@ -629,7 +630,8 @@ class PopupPlot1d(QDialog):
         [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_view_interval
         self.ui.plot_counts_vs_pixel.canvas.ax.set_xlim([ymin, ymax])
         self.ui.plot_counts_vs_pixel.canvas.ax.set_ylim([xmin, xmax])
-        # ui_plot2.canvas.draw()
+        
+        ui_plot2.canvas.draw_idle()
 
     def closeEvent(self, event=None):
         peak1 = self.ui.jim_peak1.value()

--- a/RefRed/plot/popup_plot_2d.py
+++ b/RefRed/plot/popup_plot_2d.py
@@ -225,7 +225,7 @@ class PopupPlot2d(QDialog):
 
         if self.data.all_plot_axis.yt_data_interval is None:
             self.ui.y_pixel_vs_tof_plot.canvas.ax.set_ylim(0, pixel_to)
-            self.ui.y_pixel_vs_tof_plot.canvas.draw()
+            self.ui.y_pixel_vs_tof_plot.canvas.draw_idle()
             [xmin, xmax] = self.ui.y_pixel_vs_tof_plot.canvas.ax.xaxis.get_view_interval()
             [ymin, ymax] = self.ui.y_pixel_vs_tof_plot.canvas.ax.yaxis.get_view_interval()
             self.data.all_plot_axis.yt_data_interval = [xmin, xmax, ymin, ymax]

--- a/RefRed/reduction/live_reduced_data_handler.py
+++ b/RefRed/reduction/live_reduced_data_handler.py
@@ -79,7 +79,6 @@ class LiveReducedDataHandler(object):
             yaxis_type = o_gui_utility.get_reduced_yaxis_type()
             if yaxis_type == 'RvsQ':
                 if _data.all_plot_axis.reduced_plot_RQuserView_y is None:
-                    self.parent.ui.data_stitching_plot.canvas.draw()
                     [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                     [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
                     _data.all_plot_axis.reduced_plot_RQQ4userView_x = [xmin, xmax]
@@ -91,10 +90,8 @@ class LiveReducedDataHandler(object):
                     [ymin, ymax] = _data.all_plot_axis.reduced_plot_RQuserView_y
                     self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                     self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                    self.parent.ui.data_stitching_plot.canvas.draw()
             else:
                 if _data.all_plot_axis.reduced_plot_RQ4userView_y is None:
-                    self.parent.ui.data_stitching_plot.canvas.draw()
                     [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                     [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
 
@@ -108,7 +105,8 @@ class LiveReducedDataHandler(object):
 
                     self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                     self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                    self.parent.ui.data_stitching_plot.canvas.draw()
+
+            self.parent.ui.data_stitching_plot.canvas.draw_idle()
 
             QApplication.processEvents()
 
@@ -162,7 +160,6 @@ class LiveReducedDataHandler(object):
         yaxis_type = o_gui_utility.get_reduced_yaxis_type()
         if yaxis_type == 'RvsQ':
             if _data.all_plot_axis.reduced_plot_RQuserView_y is None:
-                self.parent.ui.data_stitching_plot.canvas.draw()
                 [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                 [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
                 _data.all_plot_axis.reduced_plot_RQQ4userView_x = [xmin, xmax]
@@ -174,10 +171,8 @@ class LiveReducedDataHandler(object):
                 [ymin, ymax] = _data.all_plot_axis.reduced_plot_RQuserView_y
                 self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                 self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                self.parent.ui.data_stitching_plot.canvas.draw()
         else:
             if _data.all_plot_axis.reduced_plot_RQ4userView_y is None:
-                self.parent.ui.data_stitching_plot.canvas.draw()
                 [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                 [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
 
@@ -191,7 +186,8 @@ class LiveReducedDataHandler(object):
 
                 self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                 self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                self.parent.ui.data_stitching_plot.canvas.draw()
+
+        self.parent.ui.data_stitching_plot.canvas.draw_idle()
 
     def save_xy_axis(self):
         o_gui_utility = GuiUtility(parent=self.parent)
@@ -202,7 +198,6 @@ class LiveReducedDataHandler(object):
 
         if yaxis_type == 'RvsQ':
             if _data.all_plot_axis.reduced_plot_RQuserView_y is None:
-                self.parent.ui.data_stitching_plot.canvas.draw()
                 [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                 [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
 
@@ -216,10 +211,8 @@ class LiveReducedDataHandler(object):
 
                 self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                 self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                self.parent.ui.data_stitching_plot.canvas.draw()
         else:
             if _data.all_plot_axis.reduced_plot_RQ4QuserView_y is None:
-                self.parent.ui.data_stitching_plot.canvas.draw()
                 [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                 [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
 
@@ -233,7 +226,8 @@ class LiveReducedDataHandler(object):
 
                 self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                 self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                self.parent.ui.data_stitching_plot.canvas.draw()
+
+        self.parent.ui.data_stitching_plot.canvas.draw_idle()
 
         big_table_data[0, 0] = _data
         self.parent.big_table_data = big_table_data

--- a/RefRed/reduction/reduced_data_handler.py
+++ b/RefRed/reduction/reduced_data_handler.py
@@ -86,7 +86,6 @@ class ReducedDataHandler(object):
         yaxis_type = o_gui_utility.get_reduced_yaxis_type()
         if yaxis_type == 'RvsQ':
             if _data.all_plot_axis.reduced_plot_RQuserView_y is None:
-                self.parent.ui.data_stitching_plot.canvas.draw()
                 [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                 [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
                 _data.all_plot_axis.reduced_plot_RQQ4userView_x = [xmin, xmax]
@@ -98,10 +97,8 @@ class ReducedDataHandler(object):
                 [ymin, ymax] = _data.all_plot_axis.reduced_plot_RQuserView_y
                 self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                 self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                self.parent.ui.data_stitching_plot.canvas.draw()
         else:
             if _data.all_plot_axis.reduced_plot_RQ4userView_y is None:
-                self.parent.ui.data_stitching_plot.canvas.draw()
                 [xmin, xmax] = self.parent.ui.data_stitching_plot.canvas.ax.xaxis.get_view_interval()
                 [ymin, ymax] = self.parent.ui.data_stitching_plot.canvas.ax.yaxis.get_view_interval()
 
@@ -115,7 +112,8 @@ class ReducedDataHandler(object):
 
                 self.parent.ui.data_stitching_plot.canvas.ax.set_xlim([xmin, xmax])
                 self.parent.ui.data_stitching_plot.canvas.ax.set_ylim([ymin, ymax])
-                self.parent.ui.data_stitching_plot.canvas.draw()
+
+        self.parent.ui.data_stitching_plot.canvas.draw_idle()
 
         big_table_data[0, 0] = _data
         self.parent.big_table_data = big_table_data

--- a/RefRed/sf_calculator/sf_calculator.py
+++ b/RefRed/sf_calculator/sf_calculator.py
@@ -339,8 +339,7 @@ class SFCalculator(QtWidgets.QMainWindow):
 
         for index, _row in enumerate(list_row):
             if index == 0:
-                color = self.tableWidget.item(_row, 0).backgroundColor()
-
+                color = self.tableWidget.item(_row, 0).background()
             _item = QtWidgets.QTableWidgetItem("%s" % lambda_range[0])
             _item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
             _item.setBackground(color)
@@ -356,7 +355,7 @@ class SFCalculator(QtWidgets.QMainWindow):
         list_row = self.getListRowWithSameLambda()
         for index, _row in enumerate(list_row):
             if index == 0:
-                color = self.tableWidget.item(_row, 0).backgroundColor()
+                color = self.tableWidget.item(_row, 0).background()
             _item = QtWidgets.QTableWidgetItem("%.2f" % tof1_ms)
             _item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
             _brush_OK = QtGui.QBrush()

--- a/RefRed/sf_calculator/sf_calculator.py
+++ b/RefRed/sf_calculator/sf_calculator.py
@@ -125,13 +125,13 @@ class SFCalculator(QtWidgets.QMainWindow):
         [xmin, xmax, ymin, ymax] = self.yt_plot.toolbar.home_settings
         self.yt_plot.canvas.ax.set_xlim([xmin, xmax])
         self.yt_plot.canvas.ax.set_ylim([ymin, ymax])
-        # self.yt_plot.canvas.draw()
+        self.yt_plot.canvas.draw_idle()
 
     def homeYiPlot(self):
         [xmin, xmax, ymin, ymax] = self.yi_plot.toolbar.home_settings
         self.yi_plot.canvas.ax.set_xlim([xmin, xmax])
         self.yi_plot.canvas.ax.set_ylim([ymin, ymax])
-        # self.yi_plot.canvas.draw()
+        self.yi_plot.canvas.draw_idle()
 
     def forceSrotTableByMetaData(self):
         print("Force sorting table by metadata")
@@ -778,7 +778,6 @@ class SFCalculator(QtWidgets.QMainWindow):
             else:
                 ylim = 255
             self.yt_plot.canvas.ax.set_ylim(0, ylim)
-            # self.yt_plot.canvas.draw()
             [xmin, xmax] = self.yt_plot.canvas.ax.xaxis.get_view_interval()
             [ymin, ymax] = self.yt_plot.canvas.ax.yaxis.get_view_interval()
             nxsdata.all_plot_axis.yt_data_interval = [xmin, xmax, ymin, ymax]
@@ -789,7 +788,7 @@ class SFCalculator(QtWidgets.QMainWindow):
             [xmin, xmax, ymin, ymax] = nxsdata.all_plot_axis.yt_view_interval
             self.yt_plot.canvas.ax.set_ylim([ymin, ymax])
 
-        # self.yt_plot.canvas.draw()
+        self.yt_plot.canvas.draw_idle()
 
     def plotYI(self, nxsdata, row):
         ycountsdata = nxsdata.ycountsdata
@@ -827,7 +826,6 @@ class SFCalculator(QtWidgets.QMainWindow):
             self.yi_plot.canvas.ax.set_xscale('linear')
 
         if nxsdata.all_plot_axis.yi_data_interval is None:
-            # self.yi_plot.canvas.draw()
             [xmin, xmax] = self.yi_plot.canvas.ax.xaxis.get_view_interval()
             [ymin, ymax] = self.yi_plot.canvas.ax.yaxis.get_view_interval()
             nxsdata.all_plot_axis.yi_data_interval = [xmin, xmax, ymin, ymax]
@@ -839,7 +837,7 @@ class SFCalculator(QtWidgets.QMainWindow):
             self.yi_plot.canvas.ax.set_xlim([xmin, xmax])
             self.yi_plot.canvas.ax.set_ylim([ymin, ymax])
 
-        # self.yi_plot.canvas.draw()
+        self.yi_plot.canvas.draw_idle()
 
     def saveNXSdata(self, nxsdata, row):
         list_nxsdata_sorted = self.list_nxsdata_sorted


### PR DESCRIPTION
- Original Gitlab task: [REF181](https://code.ornl.gov/sns-hfir-scse/reflectometry/reflectometry/-/issues/181)

This PR introduces the following improvements:
- removed the reset of cursor and upgrade `canvas.draw()` to `canvas.draw_idle()` as suggested by Matplotlib
- resolved an importing error due to API change between Qt4 and Qt5
- resolved an issue caused by calling a deprecated API in `QTableWidgetItem`

Known issue:
- The `sort` button in the sf_calculator leads to a crash.  After reviewing the source code, it does not seem like this feature was fully implemented to begin with. Additional work (outside of this PR) is needed to address this issue.
