### PR TITLE
Add mypy support to the builds

### DIFF
--- a/.github/workflows/conda_env/environment.yml
+++ b/.github/workflows/conda_env/environment.yml
@@ -3,9 +3,10 @@ channels:
 - mantid
 - conda-forge
 dependencies:
-- mantid-framework=6.2.0
-- qtpy
 - configobj
+- flake8=3.9.2
+- mantid-framework=6.2.0
+- mypy
 - pytest-cov
 - pytest-qt=3.3.0
-- flake8=3.9.2
+- qtpy

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -24,7 +24,9 @@ jobs:
           mamba-version: "*"
           environment-file: .github/workflows/conda_env/environment.yml
       - name: flake8
-        run: flake8 --statistics RefRed
+        run: flake8 --statistics RefRed test scripts
+      - name: mypy type annotations
+        run: mypy RefRed test scripts
       - name: Run Tests
         run: xvfb-run -a python -m pytest --cov=RefRed --cov-report=xml --cov-report=term test
       - name: Upload coverage to Codecov

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
 # for linting and formatting
 flake8
+mypy
 pre-commit
 pytest
+pytest-cov
 pytest-runner
 pytest-xdist
-pytest-cov
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,7 @@ count = True
 exclude = docs,versioneer.py,RefRed/_version.py
 max-line-length = 119
 ignore = F403, E722, E301, W503
+
+[mypy]
+ignore_missing_imports = True
+allow_untyped_globals = True


### PR DESCRIPTION
Add mypy to the builds between flake8 and running the tests. Since we are only running mypy, make it permissive (only fail for things that have added annotations). 