### PR TITLE
Remove support for building rpm inside distutil

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,6 @@ versionfile_source = RefRed/_version.py
 versionfile_build = RefRed/_version.py
 tag_prefix = v
 
-[bdist]
-formats = rpm
-
-[bdist_rpm]
-requires = python, python2-numpy, python2-matplotlib, python2-matplotlib-qt4
-packager = Jean Bilheux <bilheuxjm@ornl.gov>
-
 [flake8]
 statistics = True
 count = True


### PR DESCRIPTION
The new deploy strategy is through conda.