### PR TITLE
black formatter options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 119
+target-version = ['py36', 'py37', 'py38']
+skip-string-normalization = true
+extend-exclude = '''
+# A regex preceded with ^/ will apply only to files and directories
+# in the root of the project.
+^/versioneer.py  # exclude file foo.py in the root of the project (in addition to the defaults)
+'''


### PR DESCRIPTION
Avoid the single-to-double quote conversion and set the same line-length as in flake8