### PR TITLE
Fix SF Calculator when using older PyQt5

### DIFF
--- a/RefRed/sf_calculator/sf_calculator.py
+++ b/RefRed/sf_calculator/sf_calculator.py
@@ -55,7 +55,14 @@ class SFCalculator(QtWidgets.QMainWindow):
     list_nxsdata_sorted = []
 
     def __init__(self, instrument=None, instrument_list=None, parent=None):
-        super(SFCalculator, self).__init__(parent)
+        super().__init__(parent)
+
+        # Application settings
+        settings = QtCore.QSettings()
+        self._save_directory = settings.value("save_directory", os.path.expanduser("~"))
+        self._xml_config_dir = settings.value("xml_config_dir", os.path.expanduser("~"))
+        self.current_loaded_file = os.path.expanduser("~/new_configuration.xml")
+
         self.ui = load_ui("sf_calculator_interface.ui", baseinstance=self)
         self.loaded_list_of_runs = []
 
@@ -66,12 +73,6 @@ class SFCalculator(QtWidgets.QMainWindow):
             "is_auto_peak_finder": True,
             "back_offset_from_peak": 3,
         }
-
-        # Application settings
-        settings = QtCore.QSettings()
-        self._save_directory = settings.value("save_directory", os.path.expanduser("~"))
-        self._xml_config_dir = settings.value("xml_config_dir", os.path.expanduser("~"))
-        self.current_loaded_file = os.path.expanduser("~/new_configuration.xml")
 
         self.initGui()
         self.checkGui()

--- a/test/ui/test_startup.py
+++ b/test/ui/test_startup.py
@@ -69,8 +69,6 @@ def test_startup(qtbot):
 
     assert window.ui.plotTab.currentIndex() == 1
     # Open and close SF Calculator
-    # this fails because of a bug in PyQt5, just disable for now, need to fix in SF Calculator
-    """
     action_rect = window.ui.menubar.actionGeometry(window.ui.menuAdvanced.menuAction())
     qtbot.mouseClick(window.ui.menubar, QtCore.Qt.LeftButton, pos=action_rect.center())
     qtbot.wait(wait)
@@ -83,7 +81,6 @@ def test_startup(qtbot):
     assert window.sf_calculator.windowTitle().startswith("SF Calculator - ")
     window.sf_calculator.close()
     qtbot.wait(wait)
-    """
 
     # Open About Dialog
     action_rect = window.ui.menubar.actionGeometry(window.ui.menuHelp.menuAction())


### PR DESCRIPTION
After this we should be able to use the version of PyQt5 available in conda and don't need to `pip install PyQt5` to the newest version