### PR TITLE
Set org and app name in QSettings

### DIFF
--- a/RefRed/__init__.py
+++ b/RefRed/__init__.py
@@ -2,3 +2,6 @@ from ._version import get_versions
 
 __version__ = get_versions()['version']
 del get_versions
+
+ORGANIZATION = 'neutrons'
+APPNAME = 'RefRed'

--- a/RefRed/configuration/user_configuration_handler.py
+++ b/RefRed/configuration/user_configuration_handler.py
@@ -1,5 +1,6 @@
 from qtpy.QtCore import QSettings
 import os
+from RefRed import ORGANIZATION, APPNAME
 from RefRed.configuration.user_configuration import UserConfiguration
 from RefRed.utilities import str2bool
 # from RefRed.settings.list_settings import ListSettings
@@ -9,7 +10,7 @@ class RetrieveUserConfiguration(object):
     def __init__(self, parent=None):
         self.parent = parent
 
-        settings = QSettings()
+        settings = QSettings(ORGANIZATION, APPNAME)
         self.parent.path_ascii = str(settings.value("path_ascii", os.path.expanduser('~')))
 
         self.parent.path_config = str(settings.value("path_config", os.path.expanduser('~')))
@@ -28,7 +29,7 @@ class SaveUserConfiguration(object):
     def __init__(self, parent=None):
         self.parent = parent
 
-        settings = QSettings()
+        settings = QSettings(ORGANIZATION, APPNAME)
         settings.setValue('path_ascii', self.parent.path_ascii)
         settings.setValue('path_config', self.parent.path_config)
 

--- a/RefRed/metadata/display_metadata.py
+++ b/RefRed/metadata/display_metadata.py
@@ -8,6 +8,7 @@ import os
 import time
 from pathlib import Path
 
+from RefRed import ORGANIZATION, APPNAME
 from RefRed.interfaces import load_ui
 from RefRed.gui_handling.gui_utility import GuiUtility
 import RefRed.utilities
@@ -176,7 +177,7 @@ class DisplayMetadata(QMainWindow):
         return [_value, _units]
 
     def retrieveListMetadataPreviouslySelected(self):
-        settings = QSettings()
+        settings = QSettings(ORGANIZATION, APPNAME)
         nbr_metadata = str(settings.value("nbr_metadata"))
         list_metadata_selected = []
         if nbr_metadata != "":
@@ -264,7 +265,7 @@ class DisplayMetadata(QMainWindow):
 
     def saveListMetadataSelected(self):
         list_metadata_selected = self.list_metadata_selected
-        settings = QSettings()
+        settings = QSettings(ORGANIZATION, APPNAME)
         nbr_metadata = len(list_metadata_selected)
         settings.setValue("nbr_metadata", nbr_metadata)
         for index, metadata in enumerate(list_metadata_selected):

--- a/RefRed/metadata/metadata_finder.py
+++ b/RefRed/metadata/metadata_finder.py
@@ -14,6 +14,7 @@ import os
 import time
 import numpy as np
 
+from RefRed import ORGANIZATION, APPNAME
 from RefRed.interfaces import load_ui
 from RefRed.calculations.run_sequence_breaker import RunSequenceBreaker
 from RefRed.decorators import waiting_effects
@@ -94,7 +95,7 @@ class MetadataFinder(QMainWindow):
         self.populateconfigureTable()
 
     def retrieveListMetadataPreviouslySelected(self):
-        settings = QSettings()
+        settings = QSettings(ORGANIZATION, APPNAME)
         nbr_metadata = str(settings.value("nbr_metadata"))
         list_metadata_selected = []
         if nbr_metadata != "":
@@ -335,7 +336,7 @@ class MetadataFinder(QMainWindow):
 
     def saveListMetadataSelected(self):
         list_metadata_selected = self.list_metadata_selected
-        settings = QSettings()
+        settings = QSettings(ORGANIZATION, APPNAME)
         nbr_metadata = len(list_metadata_selected)
         settings.setValue("nbr_metadata", nbr_metadata)
         for index, metadata in enumerate(list_metadata_selected):

--- a/RefRed/settings/initialize_settings.py
+++ b/RefRed/settings/initialize_settings.py
@@ -1,4 +1,5 @@
 from qtpy.QtCore import QSettings
+from RefRed import ORGANIZATION, APPNAME
 from RefRed.settings.list_settings import ListSettings
 
 
@@ -12,7 +13,7 @@ class InitializeSettings(object):
         o_list_settings = ListSettings()
         _list_keys = list(o_list_settings.__dict__.keys())
 
-        _settings = QSettings()
+        _settings = QSettings(ORGANIZATION, APPNAME)
         _gui_metadata = {}
         for _key in _list_keys:
             if _key == 'clocking_pixel':

--- a/RefRed/sf_calculator/sf_calculator.py
+++ b/RefRed/sf_calculator/sf_calculator.py
@@ -10,6 +10,7 @@ import numpy as np
 import logging
 import time
 
+from RefRed import ORGANIZATION, APPNAME
 import RefRed.colors
 from RefRed.interfaces import load_ui
 from RefRed.sf_calculator.fill_sf_gui_table import FillSFGuiTable
@@ -58,7 +59,7 @@ class SFCalculator(QtWidgets.QMainWindow):
         super().__init__(parent)
 
         # Application settings
-        settings = QtCore.QSettings()
+        settings = QtCore.QSettings(ORGANIZATION, APPNAME)
         self._save_directory = settings.value("save_directory", os.path.expanduser("~"))
         self._xml_config_dir = settings.value("xml_config_dir", os.path.expanduser("~"))
         self.current_loaded_file = os.path.expanduser("~/new_configuration.xml")
@@ -94,7 +95,7 @@ class SFCalculator(QtWidgets.QMainWindow):
     @save_directory.setter
     def save_directory(self, value):
         self._save_directory = value
-        settings = QtCore.QSettings()
+        settings = QtCore.QSettings(ORGANIZATION, APPNAME)
         settings.setValue("save_directory", value)
 
     @property
@@ -104,7 +105,7 @@ class SFCalculator(QtWidgets.QMainWindow):
     @xml_config_dir.setter
     def xml_config_dir(self, value):
         self._xml_config_dir = value
-        settings = QtCore.QSettings()
+        settings = QtCore.QSettings(ORGANIZATION, APPNAME)
         settings.setValue("xml_config_dir", value)
 
     def initConnections(self):


### PR DESCRIPTION
Previously the settings were going to `~/.config/Unknown\ Organization.conf` now they should go to `~/.config/neutrons/RefRed.conf`