### PR TITLE
Remove deprecated and unused dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,4 @@ mypy
 pre-commit
 pytest
 pytest-cov
-pytest-mock
 pytest-qt
-pytest-runner
-pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@ def read_requirements_from_file(filepath):
 install_requires = read_requirements_from_file(
     os.path.join(THIS_DIR, 'requirements.txt')
 )
-test_requires = read_requirements_from_file(
-    os.path.join(THIS_DIR, 'requirements_dev.txt')
-)
 
 # TODO can this be safely substituted with setuptools.find_packages?
 __packages__ = ['RefRed',
@@ -63,6 +60,4 @@ setup(name='RefRed',
       package_dir={},
       package_data={'': ['*.ui', '*.png', '*.qrc']},
       install_requires=install_requires,
-      setup_requires=["pytest-runner"],
-      tests_require=test_requires,
       )


### PR DESCRIPTION
`pytest-runner` is deprecated, see https://github.com/pytest-dev/pytest-runner/blob/main/README.rst#deprecation-notice
`tests_require` in `setup.py` is deprecated, see https://github.com/pypa/setuptools/issues/1684

`pytest-mock` and `pytest-xdist` are unused.