### PR TITLE
Turn on ErrorWeighting in LiquidsReflectometryReduction

### DIFF
--- a/RefRed/reduction/live_reduction_handler.py
+++ b/RefRed/reduction/live_reduction_handler.py
@@ -146,6 +146,7 @@ class LiveReductionHandler(object):
             ScalingFactorFile=o_general.scaling_factor_file,
             CropFirstAndLastPoints=True,
             ApplyPrimaryFraction=True,
+            ErrorWeighting=True,
             PrimaryFractionRange=o_individual._data_clocking_range,
             SlitsWidthFlag=o_general.slits_width_flag,
             OutputWorkspace=o_individual._output_workspace_name,


### PR DESCRIPTION
In older versions of Mantid this was hard-coded on, in mantid 6.2 it was made optional and defaulted to False. The change was made in https://github.com/mantidproject/mantid/pull/32129

In order to get the same results as the use case https://github.com/neutrons/RefRed/blob/next/docs/reduce-data.rst we must set `ErrorWeighting=True` for LiquidsReflectometryReduction.

@mdoucet please verify that this is the correct thing to do.
