### PR TITLE
Add decorators to optionally log function signatures

### DIFF
--- a/RefRed/decorators.py
+++ b/RefRed/decorators.py
@@ -32,7 +32,7 @@ def log_qtpy_slot(function):
 
     @wraps(function)
     def wrapper_func(ref):
-        _mantid_logger.information('qtpy slot ' + _to_call_signature(function, ref))  # TODO change to mantid logging
+        _mantid_logger.information('qtpy slot ' + _to_call_signature(function, ref))
         return function(ref)
 
     return wrapper_func
@@ -41,9 +41,7 @@ def log_qtpy_slot(function):
 def log_function(function):
     @wraps(function)
     def wrapper_func(*args, **kwargs):
-        _mantid_logger.information(
-            _to_call_signature(function, ref='', *args, **kwargs)
-        )  # TODO change to mantid logging
+        _mantid_logger.information(_to_call_signature(function, ref='', *args, **kwargs))
         print()
         return function(*args, **kwargs)
 
@@ -53,9 +51,7 @@ def log_function(function):
 def log_method(function):
     @wraps(function)
     def wrapper_func(ref, *args, **kwargs):
-        _mantid_logger.information(
-            _to_call_signature(function, ref=ref, *args, **kwargs)
-        )  # TODO change to mantid logging
+        _mantid_logger.information(_to_call_signature(function, ref=ref, *args, **kwargs))
         return function(ref, *args, **kwargs)
 
     return wrapper_func

--- a/RefRed/decorators.py
+++ b/RefRed/decorators.py
@@ -4,6 +4,62 @@
 from qtpy import QtGui, QtCore, QtWidgets
 from RefRed.version import window_title
 from functools import wraps
+from mantid.kernel import Logger
+
+
+_mantid_logger = Logger('RefRed')
+
+#
+# Wrapper functions to make logging call signatures "easy"
+#
+
+
+def _to_call_signature(func_ptr, ref='', *args, **kwargs) -> str:
+    '''Helper function to convert function call to an overly detailed string representation'''
+    result = func_ptr.__name__
+    if ref:
+        result = f'{ref}.{result}'
+    # TODO check for log level and skip converting values to string if level is too high
+    if True:
+        args_str = ', '.join([f'{item}' for item in args] + [f'{key}={value}' for key, value in kwargs.items()])
+    else:
+        args_str = ''
+    return f'{result}({args_str})'
+
+
+def log_qtpy_slot(function):
+    '''qt slots are called with a unique signature that don't appear to match the native function signature'''
+
+    @wraps(function)
+    def wrapper_func(ref):
+        _mantid_logger.information('qtpy slot ' + _to_call_signature(function, ref))  # TODO change to mantid logging
+        return function(ref)
+
+    return wrapper_func
+
+
+def log_function(function):
+    @wraps(function)
+    def wrapper_func(*args, **kwargs):
+        _mantid_logger.information(
+            _to_call_signature(function, ref='', *args, **kwargs)
+        )  # TODO change to mantid logging
+        print()
+        return function(*args, **kwargs)
+
+    return wrapper_func
+
+
+def log_method(function):
+    @wraps(function)
+    def wrapper_func(ref, *args, **kwargs):
+        _mantid_logger.information(
+            _to_call_signature(function, ref=ref, *args, **kwargs)
+        )  # TODO change to mantid logging
+        return function(ref, *args, **kwargs)
+
+    return wrapper_func
+
 
 #
 # Help functions adopted from Michele Simionato's decorator module
@@ -12,7 +68,6 @@ from functools import wraps
 
 
 def config_file_modification_reset(function):
-
     @wraps(function)
     def new_function(*args, **kw):
         mainwindow = args[0]  # first argument is the mainwindow
@@ -25,7 +80,6 @@ def config_file_modification_reset(function):
 
 
 def config_file_has_been_modified(function):
-
     @wraps(function)
     def new_function(*args, **kw):
         mainwindow = args[0]  # first argument is the ui
@@ -39,7 +93,6 @@ def config_file_has_been_modified(function):
 
 
 def waiting_effects(function):
-
     @wraps(function)
     def new_function(self, *args, **kw):
         QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))

--- a/RefRed/decorators.py
+++ b/RefRed/decorators.py
@@ -29,17 +29,17 @@ _write_log = _mantid_logger.debug  # pointer to the object's method
 #
 
 
-def _to_call_signature(func_ptr, ref='', *args, **kwargs) -> str:
+def _to_call_signature(func_ptr, ref_ptr=None, *args, **kwargs) -> str:
     '''Helper function to convert function call to an overly detailed string representation'''
-    result = func_ptr.__name__
-    if ref:
-        result = f'{ref}.{result}'
+    func_name = func_ptr.__name__
+    if ref_ptr:
+        func_name = f'{ref_ptr}.{func_name}'
     # check for log level and skip converting values to string if level is too high
     if SHOULD_LOG:
         args_str = ', '.join([f'{item}' for item in args] + [f'{key}={value}' for key, value in kwargs.items()])
     else:
         args_str = 'NOT SHOWN'
-    return f'{result}({args_str})'
+    return f'{func_name}({args_str})'
 
 
 def log_qtpy_slot(function):
@@ -56,8 +56,7 @@ def log_qtpy_slot(function):
 def log_function(function):
     @wraps(function)
     def wrapper_func(*args, **kwargs):
-        _write_log(_to_call_signature(function, ref='', *args, **kwargs))
-        print()
+        _write_log(_to_call_signature(function, ref_ptr='', *args, **kwargs))
         return function(*args, **kwargs)
 
     return wrapper_func
@@ -66,7 +65,7 @@ def log_function(function):
 def log_method(function):
     @wraps(function)
     def wrapper_func(ref, *args, **kwargs):
-        _write_log(_to_call_signature(function, ref=ref, *args, **kwargs))
+        _write_log(_to_call_signature(function, ref_ptr=ref, *args, **kwargs))
         return function(ref, *args, **kwargs)
 
     return wrapper_func


### PR DESCRIPTION
The usage is to add the decorator above a function call to see thevalues that are passed in via the value's `__repr__` method. Clients need to know which kind of function is being called and select the correct decorator.

Example usage for qt slot
```python
    @log_qtpy_slot
    def reset_button(self):
        """reset all the settings to default value hard coded in program"""
        o_list_settings = ListSettings()
        _list_keys = list(o_list_settings.__dict__.keys())
        ...
```

Example usage for member method
```python
class ListSettings(object):
    @log_method
    def __init__(self):

        self.q_min = 0.005
        self.d_q0 = 0.0004
        self.dq_over_q = 0.005
        self.tof_bin = 40  # micros
        self.q_bin = 0.01  # logarithmic binning
        self.clocking_pixel = [121, 197]
        self.angle_offset = 0.016
        self.angle_offset_error = 0.001
```

Example usage of `log_function` is left to the reader.