### PR TITLE
removed john, renamed instances of jim to plot

### DIFF
--- a/RefRed/interfaces/plot_dialog_refl_interface.ui
+++ b/RefRed/interfaces/plot_dialog_refl_interface.ui
@@ -19,590 +19,9 @@
      <property name="currentIndex">
       <number>1</number>
      </property>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tab_1">
       <attribute name="title">
-       <string>John</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="MPLWidgetXLog" name="plot_pixel_vs_counts" native="true"/>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>PEAK</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_11">
-          <item>
-           <widget class="QFrame" name="frame">
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_12">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_15">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_13">
-                 <item>
-                  <spacer name="verticalSpacer_2">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="john_peak2_label">
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="accessibleDescription">
-                    <string/>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="john_peak2">
-                   <property name="palette">
-                    <palette>
-                     <active>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>170</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </active>
-                     <inactive>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>170</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </inactive>
-                     <disabled>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>118</red>
-                         <green>118</green>
-                         <blue>117</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </disabled>
-                    </palette>
-                   </property>
-                   <property name="maximum">
-                    <number>303</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_16">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_14">
-                 <item>
-                  <widget class="QSpinBox" name="john_peak1">
-                   <property name="palette">
-                    <palette>
-                     <active>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>170</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </active>
-                     <inactive>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>170</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </inactive>
-                     <disabled>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>118</red>
-                         <green>118</green>
-                         <blue>117</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </disabled>
-                    </palette>
-                   </property>
-                   <property name="maximum">
-                    <number>303</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="john_peak1_label">
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="accessibleDescription">
-                    <string/>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_7">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>BACKGROUND</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_8">
-          <item>
-           <widget class="QFrame" name="frame_2">
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_7">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_13">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_9">
-                 <item>
-                  <widget class="QCheckBox" name="john_back_flag">
-                   <property name="text">
-                    <string>with Back.</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_3">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="john_back2_label">
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="accessibleDescription">
-                    <string/>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="john_back2">
-                   <property name="palette">
-                    <palette>
-                     <active>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>255</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </active>
-                     <inactive>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>255</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </inactive>
-                     <disabled>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>118</red>
-                         <green>118</green>
-                         <blue>117</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </disabled>
-                    </palette>
-                   </property>
-                   <property name="maximum">
-                    <number>303</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_4">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_14">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_10">
-                 <item>
-                  <spacer name="verticalSpacer_5">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="john_back1">
-                   <property name="palette">
-                    <palette>
-                     <active>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>255</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </active>
-                     <inactive>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>255</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </inactive>
-                     <disabled>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>118</red>
-                         <green>118</green>
-                         <blue>117</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </disabled>
-                    </palette>
-                   </property>
-                   <property name="maximum">
-                    <number>303</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="john_back1_label">
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="accessibleDescription">
-                    <string/>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_6">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="john_clocking_box">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>CLOCKING</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_15">
-          <item>
-           <widget class="QFrame" name="frame_6">
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_16">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_17">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_17">
-                 <item>
-                  <widget class="QSpinBox" name="john_clock2">
-                   <property name="palette">
-                    <palette>
-                     <active>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>255</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </active>
-                     <inactive>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>255</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </inactive>
-                     <disabled>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>118</red>
-                         <green>118</green>
-                         <blue>117</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </disabled>
-                    </palette>
-                   </property>
-                   <property name="maximum">
-                    <number>303</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_18">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_18">
-                 <item>
-                  <spacer name="verticalSpacer_8">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="john_clock1">
-                   <property name="palette">
-                    <palette>
-                     <active>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>255</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </active>
-                     <inactive>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>255</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </inactive>
-                     <disabled>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>118</red>
-                         <green>118</green>
-                         <blue>117</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                     </disabled>
-                    </palette>
-                   </property>
-                   <property name="maximum">
-                    <number>303</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_2">
-      <attribute name="title">
-       <string>Jim</string>
+       <string>Plot</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
@@ -641,7 +60,7 @@
                   </spacer>
                  </item>
                  <item>
-                  <widget class="QLabel" name="jim_peak1_label">
+                  <widget class="QLabel" name="plot_peak1_label">
                    <property name="font">
                     <font>
                      <pointsize>20</pointsize>
@@ -664,7 +83,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QSpinBox" name="jim_peak1">
+                  <widget class="QSpinBox" name="plot_peak1">
                    <property name="palette">
                     <palette>
                      <active>
@@ -708,7 +127,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QSpinBox" name="jim_peak2">
+                  <widget class="QSpinBox" name="plot_peak2">
                    <property name="palette">
                     <palette>
                      <active>
@@ -752,7 +171,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLabel" name="jim_peak2_label">
+                  <widget class="QLabel" name="plot_peak2_label">
                    <property name="font">
                     <font>
                      <pointsize>20</pointsize>
@@ -810,7 +229,7 @@
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_5">
              <item>
-              <widget class="QCheckBox" name="jim_back_flag">
+              <widget class="QCheckBox" name="plot_back_flag">
                <property name="text">
                 <string>with Background</string>
                </property>
@@ -830,7 +249,7 @@
               </spacer>
              </item>
              <item>
-              <widget class="QLabel" name="jim_back1_label">
+              <widget class="QLabel" name="plot_back1_label">
                <property name="font">
                 <font>
                  <pointsize>20</pointsize>
@@ -850,7 +269,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSpinBox" name="jim_back1">
+              <widget class="QSpinBox" name="plot_back1">
                <property name="palette">
                 <palette>
                  <active>
@@ -907,7 +326,7 @@
               </spacer>
              </item>
              <item>
-              <widget class="QSpinBox" name="jim_back2">
+              <widget class="QSpinBox" name="plot_back2">
                <property name="palette">
                 <palette>
                  <active>
@@ -951,7 +370,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="jim_back2_label">
+              <widget class="QLabel" name="plot_back2_label">
                <property name="font">
                 <font>
                  <pointsize>20</pointsize>
@@ -990,7 +409,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="jim_clocking_box">
+        <widget class="QGroupBox" name="plot_clocking_box">
          <property name="title">
           <string>CLOCKING</string>
          </property>
@@ -1009,7 +428,7 @@
                <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_8">
                  <item>
-                  <widget class="QSpinBox" name="jim_clock1">
+                  <widget class="QSpinBox" name="plot_clock1">
                    <property name="palette">
                     <palette>
                      <active>
@@ -1066,7 +485,7 @@
                   </spacer>
                  </item>
                  <item>
-                  <widget class="QSpinBox" name="jim_clock2">
+                  <widget class="QSpinBox" name="plot_clock2">
                    <property name="palette">
                     <palette>
                      <active>
@@ -1154,10 +573,10 @@
  </resources>
  <connections>
   <connection>
-   <sender>jim_peak1</sender>
+   <sender>plot_peak1</sender>
    <signal>editingFinished()</signal>
    <receiver>Dialog</receiver>
-   <slot>jim_peak1_spinbox_signal()</slot>
+   <slot>plot_peak1_spinbox_signal()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>587</x>
@@ -1170,26 +589,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>john_peak1</sender>
+   <sender>plot_peak2</sender>
    <signal>editingFinished()</signal>
    <receiver>Dialog</receiver>
-   <slot>john_peak1_spinbox_signal()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1027</x>
-     <y>540</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>615</x>
-     <y>500</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>jim_peak2</sender>
-   <signal>editingFinished()</signal>
-   <receiver>Dialog</receiver>
-   <slot>jim_peak2_spinbox_signal()</slot>
+   <slot>plot_peak2_spinbox_signal()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>652</x>
@@ -1202,26 +605,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>john_peak2</sender>
+   <sender>plot_back1</sender>
    <signal>editingFinished()</signal>
    <receiver>Dialog</receiver>
-   <slot>john_peak2_spinbox_signal()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1027</x>
-     <y>503</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>615</x>
-     <y>500</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>jim_back1</sender>
-   <signal>editingFinished()</signal>
-   <receiver>Dialog</receiver>
-   <slot>jim_back1_spinbox_signal()</slot>
+   <slot>plot_back1_spinbox_signal()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>327</x>
@@ -1234,26 +621,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>john_back1</sender>
+   <sender>plot_back2</sender>
    <signal>editingFinished()</signal>
    <receiver>Dialog</receiver>
-   <slot>john_back1_spinbox_signal()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1163</x>
-     <y>742</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>615</x>
-     <y>500</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>jim_back2</sender>
-   <signal>editingFinished()</signal>
-   <receiver>Dialog</receiver>
-   <slot>jim_back2_spinbox_signal()</slot>
+   <slot>plot_back2_spinbox_signal()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>913</x>
@@ -1266,26 +637,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>john_back2</sender>
-   <signal>editingFinished()</signal>
-   <receiver>Dialog</receiver>
-   <slot>john_back2_spinbox_signal()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1163</x>
-     <y>301</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>615</x>
-     <y>500</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>jim_back_flag</sender>
+   <sender>plot_back_flag</sender>
    <signal>clicked(bool)</signal>
    <receiver>Dialog</receiver>
-   <slot>jim_back_flag_clicked()</slot>
+   <slot>plot_back_flag_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>115</x>
@@ -1298,26 +653,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>john_back_flag</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>Dialog</receiver>
-   <slot>john_back_flag_clicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1142</x>
-     <y>96</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>615</x>
-     <y>500</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>jim_clock1</sender>
+   <sender>plot_clock1</sender>
    <signal>editingFinished()</signal>
    <receiver>Dialog</receiver>
-   <slot>jim_clock_spinbox_signal()</slot>
+   <slot>plot_clock_spinbox_signal()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>76</x>
@@ -1330,10 +669,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>jim_clock2</sender>
+   <sender>plot_clock2</sender>
    <signal>editingFinished()</signal>
    <receiver>Dialog</receiver>
-   <slot>jim_clock_spinbox_signal()</slot>
+   <slot>plot_clock_spinbox_signal()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1163</x>
@@ -1345,55 +684,17 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>john_clock1</sender>
-   <signal>editingFinished()</signal>
-   <receiver>Dialog</receiver>
-   <slot>john_clock_spinbox_signal()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1163</x>
-     <y>919</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>615</x>
-     <y>499</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>john_clock2</sender>
-   <signal>editingFinished()</signal>
-   <receiver>Dialog</receiver>
-   <slot>john_clock_spinbox_signal()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1163</x>
-     <y>99</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>615</x>
-     <y>499</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+</connections>
  <slots>
   <slot>update_peak1_spinbox()</slot>
   <slot>update_peak2_spinbox()</slot>
   <slot>update_back1_spinbox()</slot>
   <slot>update_back2_spinbox()</slot>
-  <slot>jim_peak1_spinbox_signal()</slot>
-  <slot>jim_peak2_spinbox_signal()</slot>
-  <slot>john_peak1_spinbox_signal()</slot>
-  <slot>john_peak2_spinbox_signal()</slot>
-  <slot>jim_back1_spinbox_signal()</slot>
-  <slot>jim_back2_spinbox_signal()</slot>
-  <slot>john_back1_spinbox_signal()</slot>
-  <slot>john_back2_spinbox_signal()</slot>
-  <slot>jim_back_flag_clicked()</slot>
-  <slot>john_back_flag_clicked()</slot>
-  <slot>jim_clock_spinbox_signal()</slot>
-  <slot>john_clock_spinbox_signal()</slot>
+  <slot>plot_peak1_spinbox_signal()</slot>
+  <slot>plot_peak2_spinbox_signal()</slot>
+  <slot>plot_back1_spinbox_signal()</slot>
+  <slot>plot_back2_spinbox_signal()</slot>
+  <slot>plot_back_flag_clicked()</slot>
+  <slot>plot_clock_spinbox_signal()</slot>
  </slots>
 </ui>

--- a/RefRed/plot/popup_plot_1d.py
+++ b/RefRed/plot/popup_plot_1d.py
@@ -107,18 +107,6 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.canvas.ax.set_xlim([ymin, ymax])
         self.ui.plot_counts_vs_pixel.draw()
 
-    def leave_plot_pixel_vs_counts(self):
-        self.ui.plot_counts_vs_pixel.canvas.ax.xaxis.set_data_interval(ymin, ymax)
-        self.ui.plot_counts_vs_pixel.canvas.ax.yaxis.set_data_interval(xmin, xmax)
-        self.data.all_plot_axis.yi_view_interval = [xmin, xmax, ymin, ymax]
-        self.update_counts_vs_pixel_plot()
-
-    def home_plot_pixel_vs_counts(self):
-        [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_data_interval
-        self.ui.plot_counts_vs_pixel.canvas.ax.set_xlim([ymin, ymax])
-        self.ui.plot_counts_vs_pixel.canvas.ax.set_ylim([xmin, xmax])
-        self.ui.plot_counts_vs_pixel.draw()
-
     def hide_and_format_invalid_widgets(self):
         palette = QPalette()
         palette.setColor(QPalette.Foreground, Qt.red)
@@ -387,16 +375,6 @@ class PopupPlot1d(QDialog):
     def update_plots(self):
         self.update_pixel_vs_counts_plot()
         self.update_counts_vs_pixel_plot()
-
-    def update_pixel_vs_counts_plot(self):
-        peak1 = self.ui.plot_peak1.value()
-        peak2 = self.ui.plot_peak2.value()
-        back1 = self.ui.plot_back1.value()
-        back2 = self.ui.plot_back2.value()
-        clock1 = self.ui.plot_clock1.value()
-        clock2 = self.ui.plot_clock2.value()
-
-        _yaxis = self.ycountsdata
 
     def update_counts_vs_pixel_plot(self):
         self.ui.plot_counts_vs_pixel.clear()

--- a/RefRed/plot/popup_plot_1d.py
+++ b/RefRed/plot/popup_plot_1d.py
@@ -283,7 +283,7 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.canvas.ax.set_ylim([xmin, xmax])
         ui_plot2.draw()
 
-        #Plot peak and back
+        # Plot peak and back
         self.set_peak_value(peak1, peak2)
         self.set_back_value(back1, back2)
         self.set_clock_value(clock1, clock2)

--- a/RefRed/plot/popup_plot_1d.py
+++ b/RefRed/plot/popup_plot_1d.py
@@ -33,8 +33,7 @@ class PopupPlot1d(QDialog):
     _prev_clock1 = -1
     _prev_clock2 = -1
 
-    isJimLog = True
-    isJohnLog = True
+    isPlotLog = True
 
     nbr_pixel_y_axis = 304
 
@@ -59,10 +58,6 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.leaveFigure.connect(self.leave_plot_counts_vs_pixel)
         self.ui.plot_counts_vs_pixel.toolbar.homeClicked.connect(self.home_plot_counts_vs_pixel)
         self.ui.plot_counts_vs_pixel.toolbar.exportClicked.connect(self.export_counts_vs_pixel)
-
-        self.ui.plot_pixel_vs_counts.leaveFigure.connect(self.leave_plot_pixel_vs_counts)
-        self.ui.plot_pixel_vs_counts.toolbar.homeClicked.connect(self.home_plot_pixel_vs_counts)
-        self.ui.plot_pixel_vs_counts.toolbar.exportClicked.connect(self.export_counts_vs_pixel)
 
         _new_detector_geometry_flag = self.data.new_detector_geometry_flag
         if not _new_detector_geometry_flag:
@@ -103,9 +98,6 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.canvas.ax.xaxis.set_data_interval(xmin, xmax)
         self.ui.plot_counts_vs_pixel.canvas.ax.yaxis.set_data_interval(ymin, ymax)
         self.ui.plot_counts_vs_pixel.draw()
-        self.ui.plot_pixel_vs_counts.canvas.ax.xaxis.set_data_interval(ymin, ymax)
-        self.ui.plot_pixel_vs_counts.canvas.ax.yaxis.set_data_interval(xmin, xmax)
-        # self.ui.plot_pixel_vs_counts.draw()
         self.data.all_plot_axis.yi_view_interval = [xmin, xmax, ymin, ymax]
         self.update_pixel_vs_counts_plot()
 
@@ -114,27 +106,15 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.canvas.ax.set_ylim([xmin, xmax])
         self.ui.plot_counts_vs_pixel.canvas.ax.set_xlim([ymin, ymax])
         self.ui.plot_counts_vs_pixel.draw()
-        self.ui.plot_pixel_vs_counts.canvas.ax.set_xlim([xmin, xmax])
-        self.ui.plot_pixel_vs_counts.canvas.ax.set_ylim([ymin, ymax])
-        self.ui.plot_pixel_vs_counts.draw()
 
     def leave_plot_pixel_vs_counts(self):
-        [xmin, xmax] = self.ui.plot_pixel_vs_counts.canvas.ax.xaxis.get_view_interval()
-        [ymin, ymax] = self.ui.plot_pixel_vs_counts.canvas.ax.yaxis.get_view_interval()
-        self.ui.plot_pixel_vs_counts.canvas.ax.xaxis.set_data_interval(xmin, xmax)
-        self.ui.plot_pixel_vs_counts.canvas.ax.yaxis.set_data_interval(ymin, ymax)
-        self.ui.plot_pixel_vs_counts.draw()
         self.ui.plot_counts_vs_pixel.canvas.ax.xaxis.set_data_interval(ymin, ymax)
         self.ui.plot_counts_vs_pixel.canvas.ax.yaxis.set_data_interval(xmin, xmax)
-        # self.ui.plot_counts_vs_pixel.draw()
         self.data.all_plot_axis.yi_view_interval = [xmin, xmax, ymin, ymax]
         self.update_counts_vs_pixel_plot()
 
     def home_plot_pixel_vs_counts(self):
         [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_data_interval
-        self.ui.plot_pixel_vs_counts.canvas.ax.set_xlim([xmin, xmax])
-        self.ui.plot_pixel_vs_counts.canvas.ax.set_ylim([ymin, ymax])
-        self.ui.plot_pixel_vs_counts.draw()
         self.ui.plot_counts_vs_pixel.canvas.ax.set_xlim([ymin, ymax])
         self.ui.plot_counts_vs_pixel.canvas.ax.set_ylim([xmin, xmax])
         self.ui.plot_counts_vs_pixel.draw()
@@ -142,70 +122,51 @@ class PopupPlot1d(QDialog):
     def hide_and_format_invalid_widgets(self):
         palette = QPalette()
         palette.setColor(QPalette.Foreground, Qt.red)
-        self.ui.jim_peak1_label.setVisible(False)
-        self.ui.jim_peak1_label.setPalette(palette)
-        self.ui.jim_peak2_label.setVisible(False)
-        self.ui.jim_peak2_label.setPalette(palette)
-        self.ui.jim_back1_label.setVisible(False)
-        self.ui.jim_back1_label.setPalette(palette)
-        self.ui.jim_back2_label.setVisible(False)
-        self.ui.jim_back2_label.setPalette(palette)
-        self.ui.john_peak1_label.setVisible(False)
-        self.ui.john_peak1_label.setPalette(palette)
-        self.ui.john_peak2_label.setVisible(False)
-        self.ui.john_peak2_label.setPalette(palette)
-        self.ui.john_back1_label.setVisible(False)
-        self.ui.john_back1_label.setPalette(palette)
-        self.ui.john_back2_label.setVisible(False)
-        self.ui.john_back2_label.setPalette(palette)
+        self.ui.plot_peak1_label.setVisible(False)
+        self.ui.plot_peak1_label.setPalette(palette)
+        self.ui.plot_peak2_label.setVisible(False)
+        self.ui.plot_peak2_label.setPalette(palette)
+        self.ui.plot_back1_label.setVisible(False)
+        self.ui.plot_back1_label.setPalette(palette)
+        self.ui.plot_back2_label.setVisible(False)
+        self.ui.plot_back2_label.setPalette(palette)
         self.ui.invalid_selection_label.setVisible(False)
         self.ui.invalid_selection_label.setPalette(palette)
 
     def sort_peak_back_input(self):
-        peak1 = self.ui.jim_peak1.value()
-        peak2 = self.ui.jim_peak2.value()
+        peak1 = self.ui.plot_peak1.value()
+        peak2 = self.ui.plot_peak2.value()
         peak_min = min([peak1, peak2])
-        # peak_max = max([peak1, peak2])
         if peak_min != peak1:
-            self.ui.jim_peak1.setValue(peak2)
-            self.ui.john_peak1.setValue(peak2)
-            self.ui.jim_peak2.setValue(peak1)
-            self.ui.john_peak2.setValue(peak1)
+            self.ui.plot_peak1.setValue(peak2)
+            self.ui.plot_peak2.setValue(peak1)
 
-        back1 = self.ui.jim_back1.value()
-        back2 = self.ui.jim_back2.value()
+        back1 = self.ui.plot_back1.value()
+        back2 = self.ui.plot_back2.value()
         back_min = min([back1, back2])
-        # back_max = max([back1, back2])
         if back_min != back1:
-            self.ui.jim_back1.setValue(back2)
-            self.ui.john_back1.setValue(back2)
-            self.ui.jim_back2.setValue(back1)
-            self.ui.john_back2.setValue(back1)
+            self.ui.plot_back1.setValue(back2)
+            self.ui.plot_back2.setValue(back1)
 
     def check_peak_back_input_validity(self):
-        peak1 = self.ui.jim_peak1.value()
-        peak2 = self.ui.jim_peak2.value()
-        back1 = self.ui.jim_back1.value()
-        back2 = self.ui.jim_back2.value()
+        peak1 = self.ui.plot_peak1.value()
+        peak2 = self.ui.plot_peak2.value()
+        back1 = self.ui.plot_back1.value()
+        back2 = self.ui.plot_back2.value()
 
         _show_widgets_1 = False
         _show_widgets_2 = False
 
-        if self.ui.jim_back_flag.isChecked():
+        if self.ui.plot_back_flag.isChecked():
             if back1 > peak1:
                 _show_widgets_1 = True
             if back2 < peak2:
                 _show_widgets_2 = True
 
-        self.ui.jim_back1_label.setVisible(_show_widgets_1)
-        self.ui.jim_peak1_label.setVisible(_show_widgets_1)
-        self.ui.jim_back2_label.setVisible(_show_widgets_2)
-        self.ui.jim_peak2_label.setVisible(_show_widgets_2)
-
-        self.ui.john_back1_label.setVisible(_show_widgets_1)
-        self.ui.john_peak1_label.setVisible(_show_widgets_1)
-        self.ui.john_back2_label.setVisible(_show_widgets_2)
-        self.ui.john_peak2_label.setVisible(_show_widgets_2)
+        self.ui.plot_back1_label.setVisible(_show_widgets_1)
+        self.ui.plot_peak1_label.setVisible(_show_widgets_1)
+        self.ui.plot_back2_label.setVisible(_show_widgets_2)
+        self.ui.plot_peak2_label.setVisible(_show_widgets_2)
 
         self.ui.invalid_selection_label.setVisible(_show_widgets_1 or _show_widgets_2)
 
@@ -218,22 +179,16 @@ class PopupPlot1d(QDialog):
             enable_status = False
 
         if not self.is_data:
-            self.ui.john_clocking_box.setVisible(False)
-            self.ui.jim_clocking_box.setVisible(False)
+            self.ui.plot_clocking_box.setVisible(False)
             return
 
-        self.ui.jim_clocking_box.setEnabled(enable_status)
-        self.ui.john_clocking_box.setEnabled(enable_status)
+        self.ui.plot_clocking_box.setEnabled(enable_status)
 
     def reset_max_ui_value(self):
-        self.ui.john_peak1.setMaximum(255)
-        self.ui.john_peak2.setMaximum(255)
-        self.ui.jim_peak1.setMaximum(255)
-        self.ui.jim_peak2.setMaximum(255)
-        self.ui.john_back1.setMaximum(255)
-        self.ui.john_back2.setMaximum(255)
-        self.ui.jim_back1.setMaximum(255)
-        self.ui.jim_back2.setMaximum(255)
+        self.ui.plot_peak1.setMaximum(255)
+        self.ui.plot_peak2.setMaximum(255)
+        self.ui.plot_back1.setMaximum(255)
+        self.ui.plot_back2.setMaximum(255)
 
     def get_ycountsdata_of_tof_range_selected(self):
         if self.data.tof_range_auto_flag:
@@ -284,8 +239,7 @@ class PopupPlot1d(QDialog):
         [clock1, clock2] = _clock
 
         back_flag = RefRed.utilities.str2bool(self.data.back_flag)
-        self.ui.jim_back_flag.setChecked(back_flag)
-        self.ui.john_back_flag.setChecked(back_flag)
+        self.ui.plot_back_flag.setChecked(back_flag)
 
         peak1 = int(peak1)
         peak2 = int(peak2)
@@ -301,57 +255,14 @@ class PopupPlot1d(QDialog):
         self._prev_clock1 = clock1
         self._prev_clock2 = clock2
 
-        # John
-        ui_plot1 = self.ui.plot_pixel_vs_counts
-        ui_plot1.plot(_yaxis, xaxis)
-        ui_plot1.canvas.ax.set_xlabel("counts")
-        ui_plot1.canvas.ax.set_ylabel("Pixels")
-        if self.isJohnLog:
-            ui_plot1.canvas.ax.set_xscale("log")
-        else:
-            ui_plot1.canvas.ax.set_xscale("linear")
-        ui_plot1.canvas.ax.set_ylim(0, self.nbr_pixel_y_axis - 1)
-        ui_plot1.canvas.ax.axhline(peak1, color=RefRed.colors.PEAK_SELECTION_COLOR)
-        ui_plot1.canvas.ax.axhline(peak2, color=RefRed.colors.PEAK_SELECTION_COLOR)
+        [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_view_interval
 
-        if self.is_data:
-            ui_plot1.canvas.ax.axhline(clock1, color=RefRed.colors.CLOCKING_SELECTION_COLOR)
-            ui_plot1.canvas.ax.axhline(clock2, color=RefRed.colors.CLOCKING_SELECTION_COLOR)
-
-        if back_flag:
-            ui_plot1.canvas.ax.axhline(back1, color=RefRed.colors.BACK_SELECTION_COLOR)
-            ui_plot1.canvas.ax.axhline(back2, color=RefRed.colors.BACK_SELECTION_COLOR)
-
-        if self.data.all_plot_axis.yi_data_interval is None:
-            ui_plot1.draw()
-            [
-                xmin,
-                xmax,
-            ] = self.ui.plot_pixel_vs_counts.canvas.ax.xaxis.get_view_interval()
-            [
-                ymin,
-                ymax,
-            ] = self.ui.plot_pixel_vs_counts.canvas.ax.yaxis.get_view_interval()
-            self.data.all_plot_axis.yi_data_interval = [xmin, xmax, ymin, ymax]
-            self.data.all_plot_axis.yi_view_interval = [xmin, xmax, ymin, ymax]
-            self.ui.plot_pixel_vs_counts.toolbar.home_settings = [
-                xmin,
-                xmax,
-                ymin,
-                ymax,
-            ]
-        else:
-            [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_view_interval
-            self.ui.plot_pixel_vs_counts.canvas.ax.set_xlim([xmin, xmax])
-            self.ui.plot_pixel_vs_counts.canvas.ax.set_ylim([ymin, ymax])
-            ui_plot1.draw()
-
-        # Jim
+        # Plot
         ui_plot2 = self.ui.plot_counts_vs_pixel
         ui_plot2.canvas.ax.plot(xaxis, _yaxis)
         ui_plot2.canvas.ax.set_xlabel("Pixels")
         ui_plot2.canvas.ax.set_ylabel("Counts")
-        if self.isJimLog:
+        if self.isPlotLog:
             ui_plot2.canvas.ax.set_yscale("log")
         else:
             ui_plot2.canvas.ax.set_yscale("linear")
@@ -372,240 +283,130 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.canvas.ax.set_ylim([xmin, xmax])
         ui_plot2.draw()
 
-        # John and Jim peak and back
+        #Plot peak and back
         self.set_peak_value(peak1, peak2)
         self.set_back_value(back1, back2)
         self.set_clock_value(clock1, clock2)
 
-        ui_plot1.logtogx.connect(self.logtogglexlog)
         ui_plot2.logtogy.connect(self.logtoggleylog)
 
-    def logtogglexlog(self, status):
-        if status == "log":
-            self.isJohnLog = True
-        else:
-            self.isJohnLog = False
-
     def logtoggleylog(self, status):
-        if status == "log":
-            self.isJimLog = True
-        else:
-            self.isJimLog = False
+        self.isPlotLog = status == "log"
 
-    def jim_back_flag_clicked(self, status):
-        self.ui.john_back_flag.setChecked(status)
-        self.data.back_flag = status
-        self.update_plots()
-        self.update_back_flag_widgets()
-        self.check_peak_back_input_validity()
-
-    def john_back_flag_clicked(self, status):
-        self.ui.jim_back_flag.setChecked(status)
+    def plot_back_flag_clicked(self, status):
         self.data.back_flag = status
         self.update_plots()
         self.update_back_flag_widgets()
         self.check_peak_back_input_validity()
 
     def update_back_flag_widgets(self):
-        status_flag = self.ui.jim_back_flag.isChecked()
-        self.ui.jim_back1.setEnabled(status_flag)
-        self.ui.jim_back2.setEnabled(status_flag)
-        self.ui.john_back1.setEnabled(status_flag)
-        self.ui.john_back2.setEnabled(status_flag)
+        status_flag = self.ui.plot_back_flag.isChecked()
+        self.ui.plot_back1.setEnabled(status_flag)
+        self.ui.plot_back2.setEnabled(status_flag)
 
     def set_peak_value(self, peak1, peak2):
-        self.ui.john_peak1.setValue(peak1)
-        self.ui.jim_peak1.setValue(peak1)
-        self.ui.john_peak2.setValue(peak2)
-        self.ui.jim_peak2.setValue(peak2)
+        self.ui.plot_peak1.setValue(peak1)
+        self.ui.plot_peak2.setValue(peak2)
         self.check_peak_back_input_validity()
 
     def set_back_value(self, back1, back2):
-        self.ui.john_back1.setValue(back1)
-        self.ui.jim_back1.setValue(back1)
-        self.ui.john_back2.setValue(back2)
-        self.ui.jim_back2.setValue(back2)
+        self.ui.plot_back1.setValue(back1)
+        self.ui.plot_back2.setValue(back2)
         self.check_peak_back_input_validity()
 
     def set_clock_value(self, clock1, clock2):
-        self.ui.john_clock1.setValue(clock1)
-        self.ui.jim_clock1.setValue(clock1)
-        self.ui.john_clock2.setValue(clock2)
-        self.ui.jim_clock2.setValue(clock2)
+        self.ui.plot_clock1.setValue(clock1)
+        self.ui.plot_clock2.setValue(clock2)
 
     # peak1
-    def update_peak1(self, value, updateJimSpinbox=True, updateJohnSpinbox=True):
-        if updateJimSpinbox:
-            self.ui.jim_peak1.setValue(value)
-        if updateJohnSpinbox:
-            self.ui.john_peak1.setValue(value)
+    def update_peak1(self, value, updatePlotSpinbox=True):
+        if updatePlotSpinbox:
+            self.ui.plot_peak1.setValue(value)
         self._prev_peak1 = value
 
-    def jim_peak1_spinbox_signal(self):
-        value = self.ui.jim_peak1.value()
+    def plot_peak1_spinbox_signal(self):
+        value = self.ui.plot_peak1.value()
         if value == self._prev_peak1:
             return
-        self.update_peak1(value, updateJimSpinbox=False)
-        self.sort_peak_back_input()
-        self.check_peak_back_input_validity()
-        self.update_plots()
-
-    def john_peak1_spinbox_signal(self):
-        value = self.ui.john_peak1.value()
-        if value == self._prev_peak1:
-            return
-        self.update_peak1(value, updateJohnSpinbox=False)
+        self.update_peak1(value, updatePlotSpinbox=False)
         self.sort_peak_back_input()
         self.check_peak_back_input_validity()
         self.update_plots()
 
     # peak2
-    def update_peak2(self, value, updateJimSpinbox=True, updateJohnSpinbox=True):
-        if updateJimSpinbox:
-            self.ui.jim_peak2.setValue(value)
-        if updateJohnSpinbox:
-            self.ui.john_peak2.setValue(value)
+    def update_peak2(self, value, updatePlotSpinbox=True):
+        if updatePlotSpinbox:
+            self.ui.plot_peak2.setValue(value)
         self._prev_peak2 = value
         self.check_peak_back_input_validity()
 
-    def jim_peak2_spinbox_signal(self):
-        value = self.ui.jim_peak2.value()
+    def plot_peak2_spinbox_signal(self):
+        value = self.ui.plot_peak2.value()
         if value == self._prev_peak2:
             return
-        self.update_peak2(value, updateJimSpinbox=False)
-        self.sort_peak_back_input()
-        self.check_peak_back_input_validity()
-        self.update_plots()
-
-    def john_peak2_spinbox_signal(self):
-        value = self.ui.john_peak2.value()
-        if value == self._prev_peak2:
-            return
-        self.update_peak2(value, updateJohnSpinbox=False)
+        self.update_peak2(value, updatePlotSpinbox=False)
         self.sort_peak_back_input()
         self.check_peak_back_input_validity()
         self.update_plots()
 
     # back1
-    def update_back1(self, value, updateJimSpinbox=True, updateJohnSpinbox=True):
-        if updateJimSpinbox:
-            self.ui.jim_back1.setValue(value)
-        if updateJohnSpinbox:
-            self.ui.john_back1.setValue(value)
+    def update_back1(self, value, updatePlotSpinbox=True):
+        if updatePlotSpinbox:
+            self.ui.plot_back1.setValue(value)
         self._prev_back1 = value
         self.check_peak_back_input_validity()
 
-    def jim_back1_spinbox_signal(self):
-        value = self.ui.jim_back1.value()
+    def plot_back1_spinbox_signal(self):
+        value = self.ui.plot_back1.value()
         if value == self._prev_back1:
             return
-        self.update_back1(value, updateJimSpinbox=False)
-        self.sort_peak_back_input()
-        self.check_peak_back_input_validity()
-        self.update_plots()
-
-    def john_back1_spinbox_signal(self):
-        value = self.ui.john_back1.value()
-        if value == self._prev_back1:
-            return
-        self.update_back1(value, updateJohnSpinbox=False)
+        self.update_back1(value, updatePlotSpinbox=False)
         self.sort_peak_back_input()
         self.check_peak_back_input_validity()
         self.update_plots()
 
     # back2
-    def update_back2(self, value, updateJimSpinbox=True, updateJohnSpinbox=True):
-        if updateJimSpinbox:
-            self.ui.jim_back2.setValue(value)
-        if updateJohnSpinbox:
-            self.ui.john_back2.setValue(value)
+    def update_back2(self, value, updatePlotSpinbox=True):
+        if updatePlotSpinbox:
+            self.ui.plot_back2.setValue(value)
         self._prev_back2 = value
         self.check_peak_back_input_validity()
 
-    def jim_back2_spinbox_signal(self):
-        value = self.ui.jim_back2.value()
+    def plot_back2_spinbox_signal(self):
+        value = self.ui.plot_back2.value()
         if value == self._prev_back2:
             return
-        self.update_back2(value, updateJimSpinbox=False)
+        self.update_back2(value, updatePlotSpinbox=False)
         self.sort_peak_back_input()
         self.check_peak_back_input_validity()
         self.update_plots()
 
-    def john_back2_spinbox_signal(self):
-        value = self.ui.john_back2.value()
-        if value == self._prev_back2:
-            return
-        self.update_back2(value, updateJohnSpinbox=False)
-        self.sort_peak_back_input()
-        self.check_peak_back_input_validity()
+    def plot_clock_spinbox_signal(self):
         self.update_plots()
-
-    def jim_clock_spinbox_signal(self):
-        self.update_clock(updateJohnSpinBox=True)
-        self.update_plots()
-
-    def john_clock_spinbox_signal(self):
-        self.update_clock(updateJohnSpinBox=False)
-        self.update_plots()
-
-    def update_clock(self, updateJohnSpinBox=True):
-        if updateJohnSpinBox:
-            self.ui.john_clock1.setValue(self.ui.jim_clock1.value())
-            self.ui.john_clock2.setValue(self.ui.jim_clock2.value())
-        else:
-            self.ui.jim_clock1.setValue(self.ui.john_clock1.value())
-            self.ui.jim_clock2.setValue(self.ui.john_clock2.value())
 
     def update_plots(self):
         self.update_pixel_vs_counts_plot()
         self.update_counts_vs_pixel_plot()
 
     def update_pixel_vs_counts_plot(self):
-        self.ui.plot_pixel_vs_counts.clear()
-
-        peak1 = self.ui.jim_peak1.value()
-        peak2 = self.ui.jim_peak2.value()
-        back1 = self.ui.jim_back1.value()
-        back2 = self.ui.jim_back2.value()
-        clock1 = self.ui.jim_clock1.value()
-        clock2 = self.ui.jim_clock2.value()
+        peak1 = self.ui.plot_peak1.value()
+        peak2 = self.ui.plot_peak2.value()
+        back1 = self.ui.plot_back1.value()
+        back2 = self.ui.plot_back2.value()
+        clock1 = self.ui.plot_clock1.value()
+        clock2 = self.ui.plot_clock2.value()
 
         _yaxis = self.ycountsdata
-
-        ui_plot1 = self.ui.plot_pixel_vs_counts
-        ui_plot1.canvas.ax.plot(_yaxis, self.xaxis)
-        ui_plot1.canvas.ax.set_xlabel("counts")
-        ui_plot1.canvas.ax.set_ylabel("Pixels")
-        if self.isJohnLog:
-            ui_plot1.canvas.ax.set_xscale("log")
-        else:
-            ui_plot1.canvas.ax.set_xscale("linear")
-        # 		ui_plot1.canvas.ax.set_ylim(0,self.nbr_pixel_y_axis-1)
-        ui_plot1.canvas.ax.axhline(peak1, color=RefRed.colors.PEAK_SELECTION_COLOR)
-        ui_plot1.canvas.ax.axhline(peak2, color=RefRed.colors.PEAK_SELECTION_COLOR)
-
-        ui_plot1.canvas.ax.axhline(clock1, color=RefRed.colors.CLOCKING_SELECTION_COLOR)
-        ui_plot1.canvas.ax.axhline(clock2, color=RefRed.colors.CLOCKING_SELECTION_COLOR)
-
-        if self.data.back_flag:
-            ui_plot1.canvas.ax.axhline(back1, color=RefRed.colors.BACK_SELECTION_COLOR)
-            ui_plot1.canvas.ax.axhline(back2, color=RefRed.colors.BACK_SELECTION_COLOR)
-
-        [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_view_interval
-        self.ui.plot_pixel_vs_counts.canvas.ax.set_xlim([xmin, xmax])
-        self.ui.plot_pixel_vs_counts.canvas.ax.set_ylim([ymin, ymax])
-
-        ui_plot1.canvas.draw_idle()
 
     def update_counts_vs_pixel_plot(self):
         self.ui.plot_counts_vs_pixel.clear()
 
-        peak1 = self.ui.jim_peak1.value()
-        peak2 = self.ui.jim_peak2.value()
-        back1 = self.ui.jim_back1.value()
-        back2 = self.ui.jim_back2.value()
-        clock1 = self.ui.jim_clock1.value()
-        clock2 = self.ui.jim_clock2.value()
+        peak1 = self.ui.plot_peak1.value()
+        peak2 = self.ui.plot_peak2.value()
+        back1 = self.ui.plot_back1.value()
+        back2 = self.ui.plot_back2.value()
+        clock1 = self.ui.plot_clock1.value()
+        clock2 = self.ui.plot_clock2.value()
 
         _yaxis = self.ycountsdata
 
@@ -613,11 +414,10 @@ class PopupPlot1d(QDialog):
         ui_plot2.canvas.ax.plot(self.xaxis, _yaxis)
         ui_plot2.canvas.ax.set_xlabel("Pixels")
         ui_plot2.canvas.ax.set_ylabel("Counts")
-        if self.isJimLog:
+        if self.isPlotLog:
             ui_plot2.canvas.ax.set_yscale("log")
         else:
             ui_plot2.canvas.ax.set_yscale("linear")
-        # 		ui_plot2.canvas.ax.set_xlim(0,self.nbr_pixel_y_axis-1)
 
         ui_plot2.canvas.ax.axvline(peak1, color=RefRed.colors.PEAK_SELECTION_COLOR)
         ui_plot2.canvas.ax.axvline(peak2, color=RefRed.colors.PEAK_SELECTION_COLOR)
@@ -636,11 +436,11 @@ class PopupPlot1d(QDialog):
         ui_plot2.canvas.draw_idle()
 
     def closeEvent(self, event=None):
-        peak1 = self.ui.jim_peak1.value()
-        peak2 = self.ui.jim_peak2.value()
-        back1 = self.ui.jim_back1.value()
-        back2 = self.ui.jim_back2.value()
-        backFlag = self.ui.jim_back_flag.isChecked()
+        peak1 = self.ui.plot_peak1.value()
+        peak2 = self.ui.plot_peak2.value()
+        back1 = self.ui.plot_back1.value()
+        back2 = self.ui.plot_back2.value()
+        backFlag = self.ui.plot_back_flag.isChecked()
 
         big_table_data = self.parent.big_table_data
 
@@ -652,8 +452,8 @@ class PopupPlot1d(QDialog):
         big_table_data[self.row, self.col] = _data
 
         if self.is_row_with_highest_q:
-            _clock1 = self.ui.jim_clock1.value()
-            _clock2 = self.ui.jim_clock2.value()
+            _clock1 = self.ui.plot_clock1.value()
+            _clock2 = self.ui.plot_clock2.value()
             _clocking = [str(_clock1), str(_clock2)]
             _data = big_table_data[0, 0]
             index = 0
@@ -673,7 +473,6 @@ class PopupPlot1d(QDialog):
             self.parent.ui.dataBackFromValue.setValue(back1)
             self.parent.ui.dataBackToValue.setValue(back2)
             self.parent.ui.dataBackgroundFlag.setChecked(backFlag)
-            # 			self.parent.data_peak_and_back_validation(False)
             self.parent.ui.dataBackFromLabel.setEnabled(backFlag)
             self.parent.ui.dataBackFromValue.setEnabled(backFlag)
             self.parent.ui.dataBackToLabel.setEnabled(backFlag)
@@ -685,7 +484,6 @@ class PopupPlot1d(QDialog):
             self.parent.ui.normBackFromValue.setValue(back1)
             self.parent.ui.normBackToValue.setValue(back2)
             self.parent.ui.normBackgroundFlag.setChecked(backFlag)
-            # 			self.parent.norm_peak_and_back_validation(False)
             self.parent.ui.normBackFromLabel.setEnabled(backFlag)
             self.parent.ui.normBackFromValue.setEnabled(backFlag)
             self.parent.ui.normBackToLabel.setEnabled(backFlag)

--- a/RefRed/plot/popup_plot_1d.py
+++ b/RefRed/plot/popup_plot_1d.py
@@ -99,7 +99,6 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.canvas.ax.yaxis.set_data_interval(ymin, ymax)
         self.ui.plot_counts_vs_pixel.draw()
         self.data.all_plot_axis.yi_view_interval = [xmin, xmax, ymin, ymax]
-        self.update_pixel_vs_counts_plot()
 
     def home_plot_counts_vs_pixel(self):
         [xmin, xmax, ymin, ymax] = self.data.all_plot_axis.yi_data_interval
@@ -373,7 +372,6 @@ class PopupPlot1d(QDialog):
         self.update_plots()
 
     def update_plots(self):
-        self.update_pixel_vs_counts_plot()
         self.update_counts_vs_pixel_plot()
 
     def update_counts_vs_pixel_plot(self):

--- a/test/ui/test_popup_plot_1d.py
+++ b/test/ui/test_popup_plot_1d.py
@@ -47,18 +47,18 @@ def test_popup_plot_1d(qtbot, main_gui):
         assert pixel(boundary) == pytest.approx(value)
 
     # test changing the peak boundaries
-    assert_boundary("peak left boundary", popup.ui.jim_peak1, 130, old_value=129)
-    assert_boundary("peak right boundary", popup.ui.jim_peak2, 142, old_value=141)
+    assert_boundary("peak left boundary", popup.ui.plot_peak1, 130, old_value=129)
+    assert_boundary("peak right boundary", popup.ui.plot_peak2, 142, old_value=141)
 
     # test changing the background boundaries
-    assert_boundary("background left boundary", popup.ui.jim_back1, 127, old_value=126)
-    assert_boundary("background right boundary", popup.ui.jim_back2, 145, old_value=144)
+    assert_boundary("background left boundary", popup.ui.plot_back1, 127, old_value=126)
+    assert_boundary("background right boundary", popup.ui.plot_back2, 145, old_value=144)
 
-    # disable/enable background options. Assumed popup.ui.jim_back_flag is initially checked
+    # disable/enable background options. Assumed popup.ui.plot_back_flag is initially checked
     for status in [False, True]:
-        qtbot.mouseClick(popup.ui.jim_back_flag, QtCore.Qt.LeftButton)
-        assert popup.ui.jim_back1.isEnabled() is status
-        assert popup.ui.jim_back2.isEnabled() is status
+        qtbot.mouseClick(popup.ui.plot_back_flag, QtCore.Qt.LeftButton)
+        assert popup.ui.plot_back1.isEnabled() is status
+        assert popup.ui.plot_back2.isEnabled() is status
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
PR addresses the depreciation of the John plot, replacing it with just the Jim plot under a different name.

**To test:**
Run the program and load a configuration from the `test/data` directory.

In the table on the bottom right check at least of of the rows as "plotted" by clicking the checkbox in the left most column.

Data should appear on the charts on the top right, click on the right most chart to open the pop up that used to contain the Jim and John plots.  There should just be one plot now.  Test to see if it functions as before but with just the on chart.


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.