### PR TITLE
correct countsxdata from lr_data

### DIFF
--- a/RefRed/calculations/lr_data.py
+++ b/RefRed/calculations/lr_data.py
@@ -315,7 +315,7 @@ class LRData(object):
         self.ytofdata = self.Ixyt.sum(axis=0)  # 2D dataset
 
         self.countstofdata = self.Ixyt.sum(axis=0).sum(axis=0)
-        self.countsxdata = self.ytofdata.sum(axis=1)
+        self.countsxdata = self.Ixyt.sum(axis=2).sum(axis=1)
         self.ycountsdata = self.ytofdata.sum(axis=1)
 
         self.data_loaded = True


### PR DESCRIPTION
- Original Gitlab Defect: [REF237](https://code.ornl.gov/sns-hfir-scse/reflectometry/reflectometry/-/issues/237)

This PR fixes an incorrect refactoring of `lr_data.countsxdata` during the modernization.
The fix is derived from pre-modernization version and should produce the correct `lr_data.countsxdata`.