### PR TITLE
Standardize version

### DIFF
--- a/RefRed/__init__.py
+++ b/RefRed/__init__.py
@@ -1,5 +1,6 @@
 from ._version import get_versions
 
+# set by versioneer
 __version__ = get_versions()['version']
 del get_versions
 

--- a/RefRed/__init__.py
+++ b/RefRed/__init__.py
@@ -6,3 +6,4 @@ del get_versions
 
 ORGANIZATION = 'neutrons'
 APPNAME = 'RefRed'
+WINDOW_TITLE = 'Liquids Reflectometer Reduction - '

--- a/RefRed/about_dialog.py
+++ b/RefRed/about_dialog.py
@@ -1,6 +1,6 @@
 from numpy.version import version as numpy_version_str
 from matplotlib import __version__ as matplotlib_version_str
-import RefRed.version
+from RefRed import __version__ as RefRed_version_str
 from qtpy import QtWidgets, QT_VERSION, PYQT_VERSION
 import sys
 import mantid
@@ -14,7 +14,6 @@ class AboutDialog(object):
         self.parent = parent
 
     def display(self):
-        RefRed_version = RefRed.version.str_version
         python_version = self.get_python_version()
         numpy_version = numpy_version_str
         mantid_version = mantid.__version__
@@ -33,7 +32,7 @@ class AboutDialog(object):
           - Matplotlib: %s
           - Qt: %s
           - PyQt: %s''' % (
-            RefRed_version,
+            RefRed_version_str,
             python_version,
             numpy_version,
             mantid_version,

--- a/RefRed/decorators.py
+++ b/RefRed/decorators.py
@@ -2,7 +2,7 @@
   Module for useful decorators
 '''
 from qtpy import QtGui, QtCore, QtWidgets
-from RefRed.version import window_title
+from RefRed import WINDOW_TITLE
 from functools import wraps
 from mantid.kernel import ConfigService, Logger
 
@@ -82,7 +82,7 @@ def config_file_modification_reset(function):
     def new_function(*args, **kw):
         mainwindow = args[0]  # first argument is the mainwindow
         current_loaded_file = mainwindow.current_loaded_file
-        str_new_window_title = "%s%s" % (window_title, current_loaded_file)
+        str_new_window_title = "%s%s" % (WINDOW_TITLE, current_loaded_file)
         mainwindow.setWindowTitle(str_new_window_title)
         function(*args, **kw)
 
@@ -95,7 +95,7 @@ def config_file_has_been_modified(function):
         mainwindow = args[0]  # first argument is the ui
         current_loaded_file = mainwindow.current_loaded_file
         mainwindow.ui.reduceButton.setEnabled(True)
-        str_new_window_title = "%s%s*" % (window_title, current_loaded_file)
+        str_new_window_title = "%s%s*" % (WINDOW_TITLE, current_loaded_file)
         mainwindow.setWindowTitle(str_new_window_title)
         function(*args, **kw)
 

--- a/RefRed/gui_handling/gui_utility.py
+++ b/RefRed/gui_handling/gui_utility.py
@@ -1,5 +1,5 @@
 from qtpy.QtCore import Qt
-from RefRed.version import window_title
+from RefRed import WINDOW_TITLE
 
 
 class GuiUtility(object):
@@ -148,16 +148,16 @@ class GuiUtility(object):
 
     def new_config_file_loaded(self, config_file_name=None):
         self.parent.current_loaded_file = config_file_name
-        dialog_title = window_title + self.parent.current_loaded_file
+        dialog_title = WINDOW_TITLE + self.parent.current_loaded_file
         self.parent.setWindowTitle(dialog_title)
 
     def gui_has_been_modified(self):
-        dialog_title = window_title + self.parent.current_loaded_file
+        dialog_title = WINDOW_TITLE + self.parent.current_loaded_file
         new_dialog_title = dialog_title + '*'
         self.parent.setWindowTitle(new_dialog_title)
 
     def gui_not_modified(self):
-        dialog_title = window_title + self.parent.current_loaded_file
+        dialog_title = WINDOW_TITLE + self.parent.current_loaded_file
         new_dialog_title = dialog_title
         self.parent.setWindowTitle(new_dialog_title)
 

--- a/RefRed/gui_handling/gui_utility.py
+++ b/RefRed/gui_handling/gui_utility.py
@@ -1,5 +1,5 @@
 from qtpy.QtCore import Qt
-import RefRed.version
+from RefRed.version import window_title
 
 
 class GuiUtility(object):
@@ -148,16 +148,16 @@ class GuiUtility(object):
 
     def new_config_file_loaded(self, config_file_name=None):
         self.parent.current_loaded_file = config_file_name
-        dialog_title = RefRed.version.window_title + self.parent.current_loaded_file
+        dialog_title = window_title + self.parent.current_loaded_file
         self.parent.setWindowTitle(dialog_title)
 
     def gui_has_been_modified(self):
-        dialog_title = RefRed.version.window_title + self.parent.current_loaded_file
+        dialog_title = window_title + self.parent.current_loaded_file
         new_dialog_title = dialog_title + '*'
         self.parent.setWindowTitle(new_dialog_title)
 
     def gui_not_modified(self):
-        dialog_title = RefRed.version.window_title + self.parent.current_loaded_file
+        dialog_title = window_title + self.parent.current_loaded_file
         new_dialog_title = dialog_title
         self.parent.setWindowTitle(new_dialog_title)
 
@@ -168,10 +168,10 @@ class GuiUtility(object):
             return 'RQ4vsQ'
 
     def getStitchingType(self):
-        '''
+        """
         return the type of stitching selected
         can be either 'auto', 'manual' or 'absolute'
-        '''
+        """
         if self.parent.ui.absolute_normalization_button.isChecked():
             return 'absolute'
         elif self.parent.ui.auto_stitching_button.isChecked():

--- a/RefRed/initialization/gui.py
+++ b/RefRed/initialization/gui.py
@@ -1,7 +1,7 @@
 from qtpy import QtGui, QtCore, QtWidgets
 import socket
 
-from RefRed.version import window_title
+from RefRed import WINDOW_TITLE
 from RefRed.configuration.export_stitching_ascii_settings import (
     ExportStitchingAsciiSettings,
 )
@@ -90,7 +90,7 @@ class Gui(object):
         parent = self.parent
 
         # title = window_title
-        parent.setWindowTitle("%s%s" % (window_title, "~/tmp.xml"))
+        parent.setWindowTitle("%s%s" % (WINDOW_TITLE, "~/tmp.xml"))
 
     def set_gui_size(self):
         screen = QtWidgets.QDesktopWidget().screenGeometry()

--- a/RefRed/reduction_table_handling/reduction_table_handler.py
+++ b/RefRed/reduction_table_handling/reduction_table_handler.py
@@ -3,7 +3,7 @@ from qtpy.QtCore import Qt
 import numpy as np
 from RefRed.plot.clear_plots import ClearPlots
 from RefRed.gui_handling.gui_utility import GuiUtility
-from RefRed.version import window_title
+from RefRed import WINDOW_TITLE
 
 
 class ReductionTableHandler(object):
@@ -22,7 +22,7 @@ class ReductionTableHandler(object):
         self.__reset_default_config_file_name()
 
     def __reset_default_config_file_name(self):
-        str_new_window_title = "%s%s" % (window_title, self.parent.default_loaded_file)
+        str_new_window_title = "%s%s" % (WINDOW_TITLE, self.parent.default_loaded_file)
         self.parent.setWindowTitle(str_new_window_title)
         self.parent.ui.previewLive.setEnabled(False)
         self.parent.ui.actionExportScript.setEnabled(False)
@@ -57,17 +57,11 @@ class ReductionTableHandler(object):
                         state, row
                     )
                     _widget.stateChanged.connect(_sig_func)
-                    self.parent.ui.reductionTable.setCellWidget(
-                        row_index, col_index, _widget
-                    )
+                    self.parent.ui.reductionTable.setCellWidget(row_index, col_index, _widget)
 
                 elif (col_index == 1) or (col_index == 2):
                     _item = QtWidgets.QTableWidgetItem()
-                    _item.setFlags(
-                        QtCore.Qt.ItemIsSelectable
-                        | QtCore.Qt.ItemIsEnabled
-                        | QtCore.Qt.ItemIsEditable
-                    )
+                    _item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable)
                     self.parent.ui.reductionTable.setItem(row_index, col_index, _item)
 
                 else:
@@ -88,17 +82,11 @@ class ReductionTableHandler(object):
             _target_row_index = _from_row + _row_offset
             for col_index in range(_nbr_col):
                 if col_index == 0:
-                    _widget = self.parent.ui.reductionTable.cellWidget(
-                        _target_row_index, col_index
-                    )
+                    _widget = self.parent.ui.reductionTable.cellWidget(_target_row_index, col_index)
                     _widget.setChecked(self.__is_row_selected_checked(row_index))
                 else:
-                    _cell_value = self.parent.ui.reductionTable.item(
-                        row_index, col_index
-                    ).text()
-                    self.parent.ui.reductionTable.item(
-                        _target_row_index, col_index
-                    ).setText(_cell_value)
+                    _cell_value = self.parent.ui.reductionTable.item(row_index, col_index).text()
+                    self.parent.ui.reductionTable.item(_target_row_index, col_index).setText(_cell_value)
             _row_offset += 1
 
     def __is_row_selected_checked(self, row_selected):
@@ -110,9 +98,7 @@ class ReductionTableHandler(object):
             return True
 
     def __get_checkbox_signal_function(self, row_index):
-        root_function_name = "self.parent.reduction_table_visibility_changed_" + str(
-            row_index
-        )
+        root_function_name = "self.parent.reduction_table_visibility_changed_" + str(row_index)
         return root_function_name
 
     def __clear_rows_big_table_data(self):
@@ -171,6 +157,4 @@ class ReductionTableHandler(object):
                 self.parent.ui.reductionTable.item(_row, _col).setText("")
 
     def __clear_big_table_data(self):
-        self.parent.big_table_data = np.empty(
-            (self.parent.nbr_row_table_reduction, 3), dtype=object
-        )
+        self.parent.big_table_data = np.empty((self.parent.nbr_row_table_reduction, 3), dtype=object)

--- a/RefRed/version.py
+++ b/RefRed/version.py
@@ -1,9 +1,2 @@
-# -*- coding: utf-8 -*-
-
 # the minor version and change date gets automatically updated on a git commit
 window_title = 'Liquids Reflectometer Reduction - '
-
-version = (3, 1)
-
-last_changes = ""
-str_version = ".".join(map(str, version))

--- a/RefRed/version.py
+++ b/RefRed/version.py
@@ -1,2 +1,0 @@
-# the minor version and change date gets automatically updated on a git commit
-window_title = 'Liquids Reflectometer Reduction - '

--- a/scripts/start_refred.py
+++ b/scripts/start_refred.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
 '''
   Small program for quick access to SNS liquids reflectometer raw data.
 '''
@@ -34,7 +33,7 @@ def _run(argv=[]):
                        </div>
                        <div>Starting up...</div>
                        </html>"""
-        % version.str_version,
+        % version,
         alignment=Qt.AlignBottom | Qt.AlignHCenter,
     )
     splash.show()
@@ -48,7 +47,7 @@ def _run(argv=[]):
 
 if __name__ == '__main__':
     # from RefRed import config
-    from RefRed import version
+    from RefRed import __version__ as version
     from RefRed.main import MainGui
 
     sys.exit(_run(sys.argv[1:]))


### PR DESCRIPTION
Versioneer was not used in the about dialog and the file `RefRed/version.py` was a potential point of confusion for future development. This moves everything to use the `__version__` supplied by versioneer and removes the old versioning mechanism.