### PR TITLE
Fix SF colour

### DIFF
--- a/.github/workflows/conda_env/environment.yml
+++ b/.github/workflows/conda_env/environment.yml
@@ -9,5 +9,5 @@ dependencies:
 - mypy
 - pytest-cov
 - pytest-qt=3.3.0
-- qtpy
+- qtpy<2
 - pyqt

--- a/.github/workflows/conda_env/environment.yml
+++ b/.github/workflows/conda_env/environment.yml
@@ -5,9 +5,10 @@ channels:
 dependencies:
 - configobj
 - flake8=3.9.2
-- mantid-framework=6.2.0
+- mantid
+- matplotlib
 - mypy
 - pytest-cov
-- pytest-qt=3.3.0
+- pytest-qt
 - qtpy<2
-- pyqt
+- pyqt=5.12

--- a/RefRed/gui_handling/fill_stitching_table.py
+++ b/RefRed/gui_handling/fill_stitching_table.py
@@ -48,16 +48,14 @@ class FillStitchingTable(ParentHandler):
         self.fillTableForAbsoluteAndAuto(_sf)
 
     def fillTableForAbsoluteAndAuto(self, _sf):
-        _brush = QtGui.QBrush()
+        _color = QtGui.QColor(QtCore.Qt.red)
         if strtobool(str(self._lconfig.sf_auto_found_match)):
-            _brush.setColor(QtCore.Qt.darkGreen)
-        else:
-            _brush.setColor(QtCore.Qt.red)
+            _color = QtGui.QColor(QtCore.Qt.darkGreen)
 
         sf = "%.4f" % _sf
         _auto_item = QtWidgets.QTableWidgetItem(sf)
         _auto_item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
-        _auto_item.setForeground(_brush)
+        _auto_item.setForeground(_color)
         self.parent.ui.dataStitchingTable.setItem(self._row_index, 1, _auto_item)
 
     def fillTableForManualStitching(self):


### PR DESCRIPTION
QBrush doesn't work in newer versions of pyqt5, user QColor instead

Fixes https://code.ornl.gov/sns-hfir-scse/reflectometry/reflectometry/-/issues/285