### PR TITLE
Update triggers to use the standard methods

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -32,14 +32,32 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
 
-      - name: Trigger ORNL GitLab Pipeline for PROD
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: curl -sX POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=main ${{ secrets.GITLAB_TRIGGER_URL }} > /dev/null
+  trigger-deploy:
+    runs-on: ubuntu-22.04
+    needs: [test-and-deploy]
+    # only trigger deploys from protected branches and tags
+    if: ${{ github.ref_protected || github.ref_type == 'tag' }}
+    steps:
+      - name: Determine Environment
+        uses: neutrons/branch-mapper@main
+        id: conda_env_name
+        with:
+          prefix: refred
 
-      - name: Trigger ORNL GitLab Pipeline for DEV
-        if: ${{ github.ref == 'refs/heads/next' }}
-        run: curl -sX POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=main -F variables[PLAY]=conda/update -F variables[CONDA_ENV]=refred-dev ${{ secrets.GITLAB_TRIGGER_URL }} > /dev/null
+      - name: Trigger deploy
+        id: trigger
+        uses: eic/trigger-gitlab-ci@v2
+        with:
+          url: https://code.ornl.gov
+          token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+          project_id: 7835
+          ref_name: main
+          variables: |
+            PLAY="update"
+            CONDA_ENV="${{ steps.conda_env_name.outputs.name }}"
 
-      - name: Trigger ORNL GitLab Pipeline for QA
-        if: ${{ github.ref == 'refs/heads/qa' }}
-        run: curl -sX POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=main -F variables[PLAY]=conda/update -F variables[CONDA_ENV]=refred-qa ${{ secrets.GITLAB_TRIGGER_URL }} > /dev/null
+      - name: Annotate commit
+        uses: peter-evans/commit-comment@v2
+        with:
+          body: |
+            GitLab pipeline for ${{ steps.conda_env_name.outputs.name }} has been submitted for this commit: ${{ steps.trigger.outputs.web_url }}


### PR DESCRIPTION
As a side benefit, failed triggers will fail the build.