### PR TITLE
Fix get_run_number function

### DIFF
--- a/RefRed/nexus_utilities.py
+++ b/RefRed/nexus_utilities.py
@@ -16,8 +16,8 @@ def findNeXusFullPath(run_number):
 def get_run_number(nexus_full_path):
     try:
         with h5py.File(nexus_full_path, 'r') as hf:
-            _run_number = hf.get('entry/run_number')
-        return _run_number[0]
+            _run_number = hf.get('entry/run_number')[0].decode()
+        return _run_number
     except:
         logger.error("Could not find run number: %s" % sys.exc_info()[1])
         return None


### PR DESCRIPTION
It was trying to read the data from a closed HDF5 file

Follow steps to reproduce in  https://code.ornl.gov/sns-hfir-scse/reflectometry/reflectometry/-/issues/411