### PR TITLE
[REF186] Resolve missing workspace attr related crash of SF_Calculator

### DIFF
--- a/RefRed/sf_calculator/lr_data.py
+++ b/RefRed/sf_calculator/lr_data.py
@@ -23,6 +23,7 @@ class LRData(object):
     is_better_chopper_coverage = True
 
     def __init__(self, workspace, read_options):
+        self.workspace = workspace  # retain the pointer for 3rd party calls
         self.read_options = read_options
         mt_run = workspace.getRun()
 


### PR DESCRIPTION
- Original Defect: [REF186](https://code.ornl.gov/sns-hfir-scse/reflectometry/reflectometry/-/issues/186)

In PR #67, the workspace attr for LRData is removed, which leads to the crash of SF calculator when the sort button is clicked.
This PR revert the single change and the crash issue should be resolved.


Testing guideline:

For those who wants to test the change without waiting for the deployment,

- on analysis cluster, clone this branch.
- make sure the system conda environment is disabled so as to avoid calling the wrong dependencies.
- setup a local dev env using either local conda or micromamba (recommended)
  - make sure install `mantidworkbench` in the test env, which provides most of the dependencies
  - install `configobj` from conda-forge
  - do an editable install for this branch with `pip install -e .`
- start RefRed by calling `scripts/RefRed` and perform the following steps
  - open the SF calculator from menu (2nd from the left)
  - load some runs by typing in `188299-188301` in the text input on top
  - wait for the load complete
  - click the sort button

Now the sf calculator should perform the sorting without crashing.




 