### PR TITLE
Trouble shoot CI failure related to Github mamba solution 

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -21,7 +21,7 @@ jobs:
         name: Setup Conda
         with:
           auto-update-conda: true
-          mamba-version: "*"
+          miniforge-version: latest
           environment-file: .github/workflows/conda_env/environment.yml
       - name: flake8
         run: flake8 --statistics RefRed test scripts


### PR DESCRIPTION
(Copied from [iMars3D PR "Trouble shoot CI failure related to Github mamba solution"](https://github.com/ornlneutronimaging/iMars3D/pull/281))

The issue is at the upstream where the provider's mamba solution is also failing (https://github.com/conda-incubator/setup-miniconda/actions/runs/3944571519/jobs/6750622433).

The goal here is to find a temp solution until the provider fixes their issue.

The workaround solution is found in this issue: https://github.com/conda-incubator/setup-miniconda/issues/274