### PR TITLE
Fix reduction options

### DIFF
--- a/.github/workflows/conda_env/environment.yml
+++ b/.github/workflows/conda_env/environment.yml
@@ -13,4 +13,4 @@ dependencies:
 - qtpy<2
 - pyqt=5.12
 - pip:
-  - git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.9#egg=lr_reduction
+  - git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.10#egg=lr_reduction

--- a/.github/workflows/conda_env/environment.yml
+++ b/.github/workflows/conda_env/environment.yml
@@ -13,4 +13,4 @@ dependencies:
 - qtpy<2
 - pyqt=5.12
 - pip:
-  - git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.8#egg=lr_reduction
+  - git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.9#egg=lr_reduction

--- a/RefRed/configuration/export_xml_config.py
+++ b/RefRed/configuration/export_xml_config.py
@@ -84,18 +84,13 @@ class ExportXMLConfig(object):
             data_low_res_flag = bool(_data.low_res_flag)
             data_lambda_requested = _data.lambda_requested
             tof = _data.tof_range
-            # tof_units = _data.tof_units
-            # tof_auto_flag = _data.tof_auto_flag
             q_range = _data.q_range
             lambda_range = _data.lambda_range
             incident_angle = _data.incident_angle
 
             _norm = _big_table_data[row, 1]
             if _norm is not None:
-                # norm_full_file_name = _norm.full_file_name
-                # if type(norm_full_file_name) == type([]):
-                # norm_full_file_name = ','.join(norm_full_file_name)
-                norm_flag = _norm.use_it_flag
+                norm_flag = o_general_settings.apply_normalization
                 norm_peak = _norm.peak
                 norm_back = _norm.back
                 norm_back_flag = _norm.back_flag
@@ -103,7 +98,6 @@ class ExportXMLConfig(object):
                 norm_low_res_flag = _norm.low_res_flag
                 norm_lambda_requested = _norm.lambda_requested
             else:
-                # norm_full_file_name = ''
                 norm_flag = False
                 norm_peak = [0, 255]
                 norm_back = [0, 255]

--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -148,6 +148,10 @@ class LoadingConfiguration(object):
         _gui_metadata['q_min'] = q_min
         self.parent.gui_metadata = _gui_metadata
 
+        # Applying normalization is a general setting for all runs
+        apply_normalization = str2bool(self.getNodeValue(node_0, 'norm_flag'))
+        self.parent.ui.useNormalizationFlag.setChecked(apply_normalization)
+
         angle_offset = self.getNodeValue(node_0, 'angle_offset')
         self.parent.ui.angleOffsetValue.setText(angle_offset)
 
@@ -185,10 +189,10 @@ class LoadingConfiguration(object):
         _low_res_max = self.getNodeValue(node, 'x_max_pixel')
         iMetadata.data_low_res = [_low_res_min, _low_res_max]
 
-        _back_flag = self.getNodeValue(node, 'background_flag')
+        _back_flag = str2bool(self.getNodeValue(node, 'background_flag'))
         iMetadata.data_back_flag = _back_flag
 
-        _low_res_flag = self.getNodeValue(node, 'x_range_flag')
+        _low_res_flag = str2bool(self.getNodeValue(node, 'x_range_flag'))
         iMetadata.data_low_res_flag = _low_res_flag
 
         _tof_min = self.getNodeValue(node, 'from_tof_range')
@@ -212,11 +216,8 @@ class LoadingConfiguration(object):
         _data_sets = _data_sets.split(',')
         iMetadata.data_sets = [str(x) for x in _data_sets]
 
-        _tof_auto = self.getNodeValue(node, 'tof_range_flag')
+        _tof_auto = str2bool(self.getNodeValue(node, 'tof_range_flag'))
         iMetadata.tof_auto_flag = _tof_auto
-
-        _norm_flag = self.getNodeValue(node, 'norm_flag')
-        iMetadata.norm_flag = _norm_flag
 
         _peak_min = self.getNodeValue(node, 'norm_from_peak_pixels')
         _peak_max = self.getNodeValue(node, 'norm_to_peak_pixels')
@@ -234,10 +235,10 @@ class LoadingConfiguration(object):
         _low_res_max = self.getNodeValue(node, 'norm_x_max')
         iMetadata.norm_low_res = [_low_res_min, _low_res_max]
 
-        _back_flag = self.getNodeValue(node, 'norm_background_flag')
+        _back_flag = str2bool(self.getNodeValue(node, 'norm_background_flag'))
         iMetadata.norm_back_flag = _back_flag
 
-        _low_res_flag = self.getNodeValue(node, 'norm_x_range_flag')
+        _low_res_flag = str2bool(self.getNodeValue(node, 'norm_x_range_flag'))
         iMetadata.norm_low_res_flag = _low_res_flag
 
         try:

--- a/RefRed/interfaces/refred_main_interface.ui
+++ b/RefRed/interfaces/refred_main_interface.ui
@@ -3599,7 +3599,7 @@ p, li { white-space: pre-wrap; }
                    <number>39</number>
                   </property>
                   <attribute name="horizontalHeaderVisible">
-                   <bool>false</bool>
+                   <bool>true</bool>
                   </attribute>
                   <attribute name="horizontalHeaderDefaultSectionSize">
                    <number>50</number>
@@ -4913,6 +4913,9 @@ p, li { white-space: pre-wrap; }
   <action name="actionSettings">
    <property name="text">
     <string>Settings ...</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionNew">

--- a/RefRed/reduction/global_reduction_settings_handler.py
+++ b/RefRed/reduction/global_reduction_settings_handler.py
@@ -23,6 +23,7 @@ class GlobalReductionSettingsHandler(object):
         self.angle_offset = self.get_angle_offset()
         self.angle_offset_error = self.get_angle_offset_error()
         self.tof_steps = self.get_tof_steps()
+        self.apply_normalization = self.parent.ui.useNormalizationFlag.isChecked()
 
     def to_dict(self):
         """
@@ -38,6 +39,7 @@ class GlobalReductionSettingsHandler(object):
             "angle_offset",
             "angle_offset_error",
             "tof_steps",
+            "apply_normalization"
         ]
         return {k: getattr(self, k) for k in keys}
 

--- a/RefRed/reduction/individual_reduction_settings_handler.py
+++ b/RefRed/reduction/individual_reduction_settings_handler.py
@@ -31,7 +31,6 @@ class IndividualReductionSettingsHandler(object):
         self._data_low_res_range = self.get_data_low_res_range()
 
         if self.norm is None:
-            self._norm_flag = False
             self._norm_run_numbers = None
             self._norm_peak_range = None
             self._norm_back_flag = None
@@ -39,7 +38,6 @@ class IndividualReductionSettingsHandler(object):
             self._norm_low_res_flag = None
             self._norm_low_res_range = None
         else:
-            self._norm_flag = self.get_norm_flag()
             self._norm_run_numbers = self.get_norm_run_numbers()
             self._norm_peak_range = self.get_norm_peak_range()
             self._norm_back_flag = self.get_norm_back_flag()
@@ -59,11 +57,10 @@ class IndividualReductionSettingsHandler(object):
             data_files=self._data_run_numbers,
             norm_file=self._norm_run_numbers,
             data_peak_range=self._data_peak_range,
-            substract_background=self._data_back_flag,
+            subtract_background=self._data_back_flag,
             background_roi=self._data_back_range,
             data_x_range_flag=self._data_low_res_flag,
             data_x_range=self._data_low_res_range,
-            apply_normalization=self._norm_flag,
             norm_peak_range=self._norm_peak_range,
             subtract_norm_background=self._norm_back_flag,
             norm_background_roi=self._norm_back_range,
@@ -133,10 +130,6 @@ class IndividualReductionSettingsHandler(object):
         low_res_min = min([low_res1, low_res2])
         low_res_max = max([low_res1, low_res2])
         return [low_res_min, low_res_max]
-
-    def get_norm_flag(self):
-        _norm = self.norm
-        return _norm.use_it_flag
 
     def get_data_back_range(self):
         _data = self.data

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,8 @@
+# RefRed Reduction Application for the Liquids Reflectometer
+
+## Release notes
+
+ - version 5 [04/2023]: RefRed v5 now uses a new reduction package <https://github.com/neutrons/LiquidsReflectometer>. Apart from being an event-based implementation of the same reduction process, the main difference with previous version is the addition of a gravity correction and the use of an effective sample-to-detector distance that takes into account the average emission time of neutrons in the moderator.
+ 
+   Other changes to version 5 include:
+    - 

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,4 +5,8 @@
  - version 5 [04/2023]: RefRed v5 now uses a new reduction package <https://github.com/neutrons/LiquidsReflectometer>. Apart from being an event-based implementation of the same reduction process, the main difference with previous version is the addition of a gravity correction and the use of an effective sample-to-detector distance that takes into account the average emission time of neutrons in the moderator.
 
    Other changes to version 5 include:
-    -
+    - The normalization option (which is a global option in the current UI) was ignored. It's now also saved properly.
+    - The boolean options in the config file were ignored because they were not loaded properly.
+    - The table headers on the main page were missing.
+    - The Settings panel is no longer useful and has been hidden until we refactor the configuration.
+    - A typo made the background subtraction option default to true.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy
 PyQt5
 qtpy
 setuptools
-lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.8#egg=lr_reduction
+lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.10#egg=lr_reduction
 

--- a/test/unit/RefRed/configuration/test_loading_configuration.py
+++ b/test/unit/RefRed/configuration/test_loading_configuration.py
@@ -171,7 +171,7 @@ class TestLoadingConfiguration(object):
             'tof_range_flag': 'tof_range_flag',
             # Applying normalization is a global setting in the application,
             # it should be treated that way when loading a template file.
-            #'norm_flag': 'norm_flag',
+            # 'norm_flag': 'norm_flag',
             'norm_from_peak_pixels': 13.013,
             'norm_to_peak_pixels': 14.014,
             'norm_from_back_pixels': 15.015,

--- a/test/unit/RefRed/configuration/test_loading_configuration.py
+++ b/test/unit/RefRed/configuration/test_loading_configuration.py
@@ -120,6 +120,8 @@ class TestLoadingConfiguration(object):
         values = {
             'q_step': 1.001,
             'q_min': 2.002,
+            # Applying normalization is a global setting
+            'norm_flag': True,
             'angle_offset': 2.5025,
             'angle_offset_error': 3.003,
             'scaling_factor_file': 'scaling_factor_file',
@@ -167,7 +169,9 @@ class TestLoadingConfiguration(object):
             'to_lambda_range': 12.012,
             'data_sets': 'dataset1, dataset2',
             'tof_range_flag': 'tof_range_flag',
-            'norm_flag': 'norm_flag',
+            # Applying normalization is a global setting in the application,
+            # it should be treated that way when loading a template file.
+            #'norm_flag': 'norm_flag',
             'norm_from_peak_pixels': 13.013,
             'norm_to_peak_pixels': 14.014,
             'norm_from_back_pixels': 15.015,
@@ -200,6 +204,7 @@ class TestLoadingConfiguration(object):
 
         expectedValue = 1.001
         for key, value in metaDict.items():
+            print(key, value)
             if isinstance(value, list):
                 for item in value:
                     if key == 'tof_range':

--- a/test/unit/RefRed/configuration/test_loading_configuration.py
+++ b/test/unit/RefRed/configuration/test_loading_configuration.py
@@ -169,9 +169,6 @@ class TestLoadingConfiguration(object):
             'to_lambda_range': 12.012,
             'data_sets': 'dataset1, dataset2',
             'tof_range_flag': 'tof_range_flag',
-            # Applying normalization is a global setting in the application,
-            # it should be treated that way when loading a template file.
-            # 'norm_flag': 'norm_flag',
             'norm_from_peak_pixels': 13.013,
             'norm_to_peak_pixels': 14.014,
             'norm_from_back_pixels': 15.015,


### PR DESCRIPTION
Some of the options in the UI were ignored and not saved in the config file.

 - The normalization option (which is a global option in the current UI) was ignored. It's now also saved properly.
 - The boolean options in the config file were ignored because they were not loaded properly.
 - The table headers on the main page were missing.
 - The Settings panel is no longer useful and has been hidden until we refactor the configuration.
 - A typo made the background subtraction option default to true.
 - Adding release notes