### PR TITLE
Update reduction version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy
 PyQt5
 qtpy
 setuptools
-lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.12#egg=lr_reduction
+lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.13#egg=lr_reduction
 


### PR DESCRIPTION
We need to update the reduction package to the latest version so that we can perform free liquid experiments and reduce data with RefRed. All that is needed is to change the dependency on lr_reduction to 2.0.13