### PR TITLE
Allow more decimals for manual scaling factors

### DIFF
--- a/RefRed/gui_handling/fill_stitching_table.py
+++ b/RefRed/gui_handling/fill_stitching_table.py
@@ -70,5 +70,6 @@ class FillStitchingTable(ParentHandler):
         sf_manual = self._lconfig.sf_manual
         _widget_manual.setValue(sf_manual)
         _widget_manual.setSingleStep(0.001)
+        _widget_manual.setDecimals(6)
         _widget_manual.valueChanged.connect(self.parent.data_stitching_table_manual_spin_box)
         self.parent.ui.dataStitchingTable.setCellWidget(self._row_index, 1, _widget_manual)


### PR DESCRIPTION
We need to add more digits to the scaling factors users can enter. At the moment it's limited to 2.