### PR TITLE
Skip auto peak finder when reloading the same run in the reduction table

### DIFF
--- a/RefRed/calculations/check_list_run_compatibility_thread.py
+++ b/RefRed/calculations/check_list_run_compatibility_thread.py
@@ -107,10 +107,26 @@ class CheckListRunCompatibilityThread(QtCore.QThread):
         self.parent.big_table_data = big_table_data
 
     def loading_lr_data(self):
+        """Updates data table with the new run."""
         wks = self.wks
         lrdata = LRData(wks, parent=self.parent)
         self.lrdata = lrdata
         big_table_data = self.parent.big_table_data
         col_index = 0 if self.is_working_with_data_column else 1
+        # keep existing user config if the new run number is the same as the old one
+        if self.is_reloading_same_run():
+            lrdata.peak = big_table_data[self.row, col_index].peak
+            lrdata.back = big_table_data[self.row, col_index].back
+            lrdata.low_res = big_table_data[self.row, col_index].low_res
         big_table_data[self.row, col_index] = lrdata
         self.parent.big_table_data = big_table_data
+
+    def is_reloading_same_run(self):
+        """Checks if the new run number is the same as the old, i.e. the run is being reloaded."""
+        col_index = 0 if self.is_working_with_data_column else 1
+        big_table_data_run = self.parent.big_table_data[self.row, col_index]
+        if big_table_data_run is not None and (
+            big_table_data_run.run_number == self.parent.ui.reductionTable.item(self.row, self.col).text()
+        ):
+            return True
+        return False

--- a/RefRed/main.py
+++ b/RefRed/main.py
@@ -52,7 +52,7 @@ from RefRed.config.mantid_config import MantidConfig
 class MainGui(QtWidgets.QMainWindow):
     '''Top class that handles the GUI'''
 
-    file_loaded_signal = QtCore.Signal()
+    file_loaded_signal = QtCore.Signal(int, bool, bool)
 
     # default location
     path_ascii = '.'  # ascii file such as scaling factor file

--- a/RefRed/reduction_table_handling/reduction_table_check_box.py
+++ b/RefRed/reduction_table_handling/reduction_table_check_box.py
@@ -57,6 +57,9 @@ class ReductionTableCheckBox(object):
         if self.is_row_selected_checked(_row_selected):
             _big_table_data = self.parent.big_table_data
             _lconfig = _big_table_data[_row_selected, 2]
+            if not _lconfig:
+                # no data loaded on this row
+                return
             if bool(_lconfig.tof_auto_flag):
                 self.parent.ui.dataTOFautoMode.setChecked(True)
             else:

--- a/RefRed/reduction_table_handling/update_reduction_table.py
+++ b/RefRed/reduction_table_handling/update_reduction_table.py
@@ -19,15 +19,15 @@ class UpdateReductionTable(object):
         self.row = row
         self.col = col
 
+        data_type = 'data' if col == 1 else 'norm'
+        self.is_data_displayed = True if (col == 1) else False
+
         item = self.parent.ui.reductionTable.item(row, col)
         if item.text() == '':
             self.clear_cell(row, col)
-            self.parent.file_loaded_signal.emit()
+            self.parent.file_loaded_signal.emit(row, self.is_data_displayed, self.display_of_this_row_checked())
             QApplication.processEvents()
             return
-
-        data_type = 'data' if col == 1 else 'norm'
-        self.is_data_displayed = True if (col == 1) else False
 
         self.raw_runs = str(runs)
         run_breaker = RunSequenceBreaker(run_sequence=self.raw_runs)
@@ -85,6 +85,9 @@ class UpdateReductionTable(object):
         # Note: there is a Mantid process cleaning process elsewhere in the code
         # so we don't have to deal with it here.
         config = self.parent.big_table_data[self.row, 2]
+        if config is None:
+            # no data loaded in this row
+            return
         if col == 1:
             self.parent.big_table_data[self.row, 0] = None
             config.clear_data()

--- a/development.yml
+++ b/development.yml
@@ -1,12 +1,13 @@
 name: refred
 channels:
-  - mantid
+  - mantid/label/main
   - conda-forge
   - defaults
 dependencies:
-  - mantid==6.4
+  - python=3.8
+  - mantidworkbench>=6.7.0
   - qt>=5.12.9,<6
-  - pyqt>=5.12.3,<5.15
+  - pyqt>=5.12.3
   - qtpy>=1.9.0
   - pip
   - configobj

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -113,3 +113,21 @@ def main_gui(qtbot, data_server):
         return window
 
     return _main_gui
+
+
+@pytest.fixture
+def file_finder_find_runs(data_server):
+    """Fixture to add as side effect for mock of FileFinder.findRuns to locate runs in the test data directory
+
+    Usage:
+    @mock.patch("RefRed.calculations.locate_list_run.FileFinder.findRuns")
+    def test_update_reduction_table(mock_file_finder_find_runs, file_finder_find_runs):
+        mock_file_finder_find_runs.side_effect = file_finder_find_runs
+    :return function: function to add as side effect to mock of FileFinder.findRuns
+    """
+
+    def _file_finder_find_runs(file_hint: str):
+        """Get path to file in test data directory"""
+        return data_server.path_to(f"{file_hint}.nxs.h5")
+
+    return _file_finder_find_runs

--- a/test/unit/RefRed/reduction_table_handling/test_update_reduction_table.py
+++ b/test/unit/RefRed/reduction_table_handling/test_update_reduction_table.py
@@ -83,3 +83,37 @@ def test_update_reduction_table_thread(
 
     # check that the reduction table was re-enabled after the thread returned
     assert window_main.ui.reductionTable.isEnabled()
+
+
+@pytest.mark.parametrize("column", [1, 2])  # data run column, normalization run column
+@mock.patch("RefRed.reduction_table_handling.update_reduction_table.LocateListRun")
+def test_update_reduction_table_clear_cell(mock_locate_list_run, data_server, qtbot, column):
+    """Test pressing Enter in empty cell in the reduction table"""
+    mock_locate_list_run.return_value = MockLocateListRun()
+
+    window_main = MainGui()
+    qtbot.addWidget(window_main)
+
+    # test pressing Enter in empty cell before any data has been loaded
+    window_main.ui.reductionTable.setCurrentCell(0, column)
+    window_main.ui.table_reduction_cell_enter_pressed()
+    qtbot.wait(wait)
+    # check that the reduction table was re-enabled after the function returned
+    assert window_main.ui.reductionTable.isEnabled()
+
+    # test first loading a run, then clearing the cell and pressing Enter to clear loaded data
+    window_main.ui.reductionTable.setCurrentCell(0, column)
+    window_main.ui.reductionTable.currentItem().setText("184975")
+    window_main.ui.table_reduction_cell_enter_pressed()
+    qtbot.wait(5000)
+    # check that the data has been loaded
+    assert window_main.big_table_data[0, column - 1] is not None
+    # clear the cell and press Enter to clear the data
+    window_main.ui.reductionTable.setCurrentCell(0, column)
+    window_main.ui.reductionTable.currentItem().setText("")
+    window_main.ui.table_reduction_cell_enter_pressed()
+    qtbot.wait(wait)
+    # check that the reduction table was re-enabled after the function returned
+    assert window_main.ui.reductionTable.isEnabled()
+    # check that the data has been cleared
+    assert window_main.big_table_data[0, column - 1] is None


### PR DESCRIPTION
Resolves [Story 2737: [RefRed] skip auto-peak finder when replacing a run](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2737)

- Fix bug where RefRed crashes when pressing Enter in an empty cell in the reduction table
- Fix bug where RefRed crashes when checking the "Plotted" checkbox for an empty row of the reduction table
- Change behavior so that when the user presses Enter in a cell of the reduction table, the run is reloaded but the settings for peak and background ranges are not changed. However, if the run number is different, the auto-peak finder is used and the settings updated.