### PR TITLE
Skip auto-peak finder also when loading a different run

### DIFF
--- a/RefRed/calculations/check_list_run_compatibility_thread.py
+++ b/RefRed/calculations/check_list_run_compatibility_thread.py
@@ -104,29 +104,14 @@ class CheckListRunCompatibilityThread(QtCore.QThread):
             _lconfig.norm_runs_compatible = runs_are_compatible
 
         big_table_data[self.row, 2] = _lconfig
-        self.parent.big_table_data = big_table_data
 
     def loading_lr_data(self):
         """Updates data table with the new run."""
         wks = self.wks
-        lrdata = LRData(wks, parent=self.parent)
-        self.lrdata = lrdata
         big_table_data = self.parent.big_table_data
         col_index = 0 if self.is_working_with_data_column else 1
-        # keep existing user config if the new run number is the same as the old one
-        if self.is_reloading_same_run():
-            lrdata.peak = big_table_data[self.row, col_index].peak
-            lrdata.back = big_table_data[self.row, col_index].back
-            lrdata.low_res = big_table_data[self.row, col_index].low_res
+        big_table_cell = big_table_data[self.row, col_index]
+        # when loading a run in an existing cell, big_table_cell is not None and LRData will copy existing config
+        lrdata = LRData(wks, parent=self.parent, reduction_table_cell=big_table_cell)
+        self.lrdata = lrdata
         big_table_data[self.row, col_index] = lrdata
-        self.parent.big_table_data = big_table_data
-
-    def is_reloading_same_run(self):
-        """Checks if the new run number is the same as the old, i.e. the run is being reloaded."""
-        col_index = 0 if self.is_working_with_data_column else 1
-        big_table_data_run = self.parent.big_table_data[self.row, col_index]
-        if big_table_data_run is not None and (
-            big_table_data_run.run_number == self.parent.ui.reductionTable.item(self.row, self.col).text()
-        ):
-            return True
-        return False

--- a/test/unit/RefRed/reduction_table_handling/test_update_reduction_table.py
+++ b/test/unit/RefRed/reduction_table_handling/test_update_reduction_table.py
@@ -77,37 +77,41 @@ def test_load_run_auto_peak_finder(mock_file_finder_find_runs, mock_display_plot
     qtbot.addWidget(window_main)
 
     run1 = "188300"
-    expected_peak_run1 = ["130", "141"]
-    expected_back_run1 = ["127", "144"]
     run2 = "188301"
-    expected_peak_run2 = ["130", "139"]
-    expected_back_run2 = ["127", "142"]
+    expected_peak = ["130", "141"]
+    expected_back = ["127", "144"]
+    expected_tof_range_auto = [31420.7610, 44712.6203]
 
     # load the first run
     load_run_from_reduction_table(window_main, row=0, col=1, run=run1)
     qtbot.wait(wait)
     # check the result of the auto-peak finder
-    assert window_main.big_table_data[0, 0].peak == expected_peak_run1
-    assert window_main.big_table_data[0, 0].back == expected_back_run1
+    assert window_main.big_table_data[0, 0].peak == expected_peak
+    assert window_main.big_table_data[0, 0].back == expected_back
+    assert window_main.big_table_data[0, 0].tof_range_auto == pytest.approx(expected_tof_range_auto, 1e-6)
 
     # modify the peak and background ranges (users can change these in the UI)
     user_set_peak = ["132", "143"]
     user_set_back = ["128", "147"]
+    user_set_tof = [31500.0, 44700.0]
     window_main.big_table_data[0, 0].peak = user_set_peak
     window_main.big_table_data[0, 0].back = user_set_back
+    window_main.big_table_data[0, 0].tof_range_auto = user_set_tof
     # reload the same run
     load_run_from_reduction_table(window_main, row=0, col=1, run=run1)
     qtbot.wait(wait)
     # check that the auto-peak finder did not change the peak and background ranges
     assert window_main.big_table_data[0, 0].peak == user_set_peak
     assert window_main.big_table_data[0, 0].back == user_set_back
+    assert window_main.big_table_data[0, 0].tof_range_auto == pytest.approx(user_set_tof, 1e-6)
 
     # load a different run in the cell
     load_run_from_reduction_table(window_main, row=0, col=1, run=run2)
     qtbot.wait(wait)
     # check that the peak and background ranges were updated
-    assert window_main.big_table_data[0, 0].peak == expected_peak_run2
-    assert window_main.big_table_data[0, 0].back == expected_back_run2
+    assert window_main.big_table_data[0, 0].peak == user_set_peak
+    assert window_main.big_table_data[0, 0].back == user_set_back
+    assert window_main.big_table_data[0, 0].tof_range_auto == pytest.approx(user_set_tof, 1e-6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes:
- skip auto-peak finder also when loading a different run
- also skip updating the TOF range

If the table cell being loaded already had a loaded run, use the existing configuration for peak, background, low res and TOF ranges.