### PR TITLE
Add background settings UI and functionality

### DIFF
--- a/RefRed/interfaces/__init__.py
+++ b/RefRed/interfaces/__init__.py
@@ -1,8 +1,12 @@
+# standard imports
 import os
+
+# third party imports
+from qtpy.QtWidgets import QWidget
 from qtpy.uic import loadUi
 
 
-def load_ui(ui_filename, baseinstance):
+def load_ui(ui_filename: str, baseinstance: QWidget):
     ui_filename = os.path.split(ui_filename)[-1]
     ui_path = os.path.dirname(__file__)
 

--- a/RefRed/interfaces/background_settings.ui
+++ b/RefRed/interfaces/background_settings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>260</width>
+    <height>160</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,15 +18,15 @@
     <rect>
      <x>13</x>
      <y>19</y>
-     <width>381</width>
-     <height>261</height>
+     <width>241</width>
+     <height>131</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QCheckBox" name="checkBox">
+       <widget class="QCheckBox" name="subtract_background">
         <property name="text">
          <string/>
         </property>
@@ -45,12 +45,25 @@
         </property>
        </widget>
       </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QCheckBox" name="checkBox_2">
+       <widget class="QCheckBox" name="functional_background">
         <property name="text">
          <string/>
         </property>
@@ -66,12 +79,25 @@
         </property>
        </widget>
       </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
-       <widget class="QCheckBox" name="checkBox_3">
+       <widget class="QCheckBox" name="two_backgrounds">
         <property name="text">
          <string/>
         </property>
@@ -86,6 +112,19 @@
          <string>Use two background regions</string>
         </property>
        </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </item>

--- a/RefRed/interfaces/refred_main_interface.ui
+++ b/RefRed/interfaces/refred_main_interface.ui
@@ -2453,7 +2453,7 @@ p, li { white-space: pre-wrap; }
                                </layout>
                               </item>
                               <item>
-                               <widget class="QPushButton" name="pushButton">
+                               <widget class="QPushButton" name="mainBackgroundSettingsPushButton">
                                 <property name="text">
                                  <string>Background</string>
                                 </property>
@@ -6401,6 +6401,22 @@ p, li { white-space: pre-wrap; }
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>mainBackgroundSettingsPushButton</sender>
+   <signal>pressed()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>display_background_settings</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1626</x>
+     <y>684</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>873</x>
+     <y>699</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <signal>signal1()</signal>
@@ -6408,6 +6424,7 @@ p, li { white-space: pre-wrap; }
   <slot>data_back_spinbox_validation()</slot>
   <slot>back_from_value_changed()</slot>
   <slot>back_to_value_changed()</slot>
+  <slot>display_background_settings</slot>
   <slot>norm_peak_spinbox_validation()</slot>
   <slot>data_peak_spinbox_validation()</slot>
   <slot>peak_from_value_changed()</slot>

--- a/RefRed/main.py
+++ b/RefRed/main.py
@@ -33,6 +33,7 @@ from RefRed.plot.single_click_plot import SingleClickPlot
 from RefRed.plot.home_plot_button_clicked import HomePlotButtonClicked
 from RefRed.plot.mouse_leave_plot import MouseLeavePlot
 from RefRed.plot.log_plot_toggle import LogPlotToggle
+from RefRed.plot.background_settings import BackgroundSettingsModel, BackgroundSettingsView
 from RefRed.preview_config.preview_config import PreviewConfig
 from RefRed.reduction.live_reduction_handler import LiveReductionHandler
 from RefRed.reduction.reduced_data_handler import ReducedDataHandler
@@ -135,6 +136,7 @@ class MainGui(QtWidgets.QMainWindow):
         logging.basicConfig(filename=log_file, level=logging.DEBUG)
 
         self.spinbox_observer = SpinBoxObserver()  # backup the last value for each spinbox in this widget
+        self.background_settings = BackgroundSettingsModel(main_window=self)
 
     # home button of plots
     def home_clicked_yi_plot(self):
@@ -262,6 +264,10 @@ class MainGui(QtWidgets.QMainWindow):
     @config_file_has_been_modified
     def data_back_spinbox_validation(self, *args, **kwargs):
         DataBackSpinbox(parent=self)
+
+    @config_file_has_been_modified
+    def display_background_settings(self, *args, **kwargs):
+        BackgroundSettingsView(parent=self).show()
 
     def back_from_value_changed(self, *args, **kwargs):
         r"""Slot handing signal QSpinBox.valueChanged(int) for QSpinBox backFromValue, denoting

--- a/RefRed/plot/background_settings.py
+++ b/RefRed/plot/background_settings.py
@@ -1,0 +1,80 @@
+# standard imports
+
+# third-party imports
+from qtpy.QtWidgets import QDialog, QCheckBox, QWidget
+
+# application imports
+from RefRed.interfaces import load_ui
+
+
+class BackgroundSettingsModel:
+    r"""Singleton class storing settings for the background
+
+    Parameters
+    ----------
+    main_window
+        reference to the application's main window
+    """
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            if kwargs["main_window"] is None:
+                raise ValueError("A widget for `main_window` is required at first instantiation")
+            cls._instance = super(BackgroundSettingsModel, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self, main_window: QWidget = None):
+        self.main_window = main_window
+        self._subtract_background = True
+        self._functional_background = False
+        self._two_backgrounds = False
+
+    @property
+    def subtract_background(self) -> bool:
+        return self._subtract_background
+
+    @subtract_background.setter
+    def subtract_background(self, value: bool):
+        self._subtract_background = value
+
+    @property
+    def functional_background(self) -> bool:
+        return self._functional_background
+
+    @functional_background.setter
+    def functional_background(self, value: bool):
+        self._functional_background = value
+
+    @property
+    def two_backgrounds(self) -> bool:
+        return self._two_backgrounds
+
+    @two_backgrounds.setter
+    def two_backgrounds(self, value: bool):
+        self._two_backgrounds = value
+
+
+class BackgroundSettingsView(QDialog):
+
+    # checkbox names as well as names for the model properties
+    options = ["subtract_background", "functional_background", "two_backgrounds"]
+
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)
+        self.ui = load_ui(ui_filename="background_settings.ui", baseinstance=self)
+        self.model = BackgroundSettingsModel()  # fetch the singleton model
+        self._update_view()
+
+    def _update_view(self, option: str = None):
+        r"""Fetch current boolean option(s) from the model"""
+        options = self.options if option is None else [option]
+        for _option in options:
+            value: bool = getattr(self.model, _option)
+            checkbox: QCheckBox = getattr(self.ui, _option)
+            checkbox.setChecked(value)
+
+    def _update_model(self, option: str) -> None:
+        checkbox: QCheckBox = getattr(self.ui, option)
+        value = checkbox.isChecked()  # True if checkbox is checked
+        setattr(self.model, option, value)


### PR DESCRIPTION
Added a new dialog for background settings in RefRed. The settings include the options to subtract background, use functional background, and use two background regions. A new model to store the options and a signal to display the dialog were also implemented.

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
