### PR TITLE
enforce requirements in sync

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -27,6 +27,8 @@ jobs:
         run: flake8 --statistics RefRed test scripts
       - name: mypy type annotations
         run: mypy RefRed test scripts
+      - name: dependencies synced
+        run: python ./scripts/sync_dependencies.py
       - name: Run Tests
         run: xvfb-run -a python -m pytest -vv --cov=RefRed --cov-report=xml --cov-report=term test
       - name: Upload coverage to Codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy
 PyQt5
 qtpy
 setuptools
-lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.13#egg=lr_reduction
+lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.0.18#egg=lr_reduction
 

--- a/scripts/sync_dependencies.py
+++ b/scripts/sync_dependencies.py
@@ -1,0 +1,30 @@
+# standard imports
+import logging
+import os
+import re
+import sys
+
+script_dir: str = os.path.dirname(os.path.realpath(__file__))
+repo_dir: str = os.path.dirname(script_dir)
+
+
+def check_dependencies_synced():
+    r"""Check that the dependencies of environment.yml and requirements.txt are in sync"""
+
+    conda_env = open(os.path.join(repo_dir, "environment.yml"), "r").read()
+    reqs_env = open(os.path.join(repo_dir, "requirements.txt"), "r").read()
+
+    # check for LiquidsReflectometer versions
+    lr_conda = re.search(r'LiquidsReflectometer\.git@([^#]+)', conda_env).group(1)
+    lr_reqs = re.search(r'LiquidsReflectometer\.git@([^#]+)', reqs_env).group(1)
+    if lr_conda != lr_reqs:
+        raise RuntimeError("environment.yml and requirements.txt ask different versions of LiquidsReflectometer")
+
+
+if __name__ == "__main__":
+    try:
+        check_dependencies_synced()
+    except RuntimeError as e:
+        logging.error(f"{e}")
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
# Short description of the changes:
Sanity check inserted in GitHub actions. It makes sure that the LiquidsReflectometer version required in the conda environment file and the pip requirements file is the same

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
