### PR TITLE
Remove functional background from background settings

### DIFF
--- a/RefRed/calculations/lr_data.py
+++ b/RefRed/calculations/lr_data.py
@@ -182,7 +182,6 @@ class LRData(object):
         self.back: List[int] = [0, 0]  # lower and upper boundaries for the first background
         self.back2: List[int] = [0, 0]  # lower and upper boundaries for the second background
         self.back_flag: bool = True
-        self.functional_background: bool = False
         self.two_backgrounds: bool = False
 
         self.all_plot_axis = AllPlotAxis()
@@ -202,7 +201,6 @@ class LRData(object):
                 self.low_res = [int(lconfig.data_low_res[0]), int(lconfig.data_low_res[1])]
                 self.low_res_flag = bool(lconfig.data_low_res_flag)
                 self.back_flag = bool(lconfig.data_back_flag)
-                self.functional_background = bool(lconfig.data_functional_background)
                 self.two_backgrounds = bool(lconfig.data_two_backgrounds)
             else:
                 self.peak = [int(lconfig.norm_peak[0]), int(lconfig.norm_peak[1])]
@@ -211,7 +209,6 @@ class LRData(object):
                 self.low_res = [int(lconfig.norm_low_res[0]), int(lconfig.norm_low_res[1])]
                 self.low_res_flag = bool(lconfig.norm_low_res_flag)
                 self.back_flag = bool(lconfig.norm_back_flag)
-                self.functional_background = bool(lconfig.norm_functional_background)
                 self.two_backgrounds = bool(lconfig.norm_two_backgrounds)
 
         elif reduction_table_cell is not None:
@@ -225,7 +222,6 @@ class LRData(object):
             self.low_res = reduction_table_cell.low_res
             self.low_res_flag = reduction_table_cell.low_res_flag
             self.back_flag = reduction_table_cell.back_flag
-            self.functional_background = reduction_table_cell.functional_background
             self.two_backgrounds = reduction_table_cell.two_backgrounds
 
         else:

--- a/RefRed/configuration/export_xml_config.py
+++ b/RefRed/configuration/export_xml_config.py
@@ -89,7 +89,6 @@ class ExportXMLConfig(object):
             data_back2 = _data.back2
             data_low_res = _data.low_res
             data_back_flag = _data.back_flag
-            data_functional_background = _data.functional_background
             data_two_backgrounds = _data.two_backgrounds
             data_low_res_flag = bool(_data.low_res_flag)
             data_lambda_requested = _data.lambda_requested
@@ -105,7 +104,6 @@ class ExportXMLConfig(object):
                 norm_back = _norm.back
                 norm_back2 = _norm.back2
                 norm_back_flag = _norm.back_flag
-                norm_functional_background = _norm.functional_background
                 norm_two_backgrounds = _norm.two_backgrounds
 
                 norm_low_res = _norm.low_res
@@ -116,7 +114,6 @@ class ExportXMLConfig(object):
                 norm_peak = [0, 255]
                 norm_back = [0, 255]
                 norm_back_flag = False
-                norm_functional_background = False
                 norm_two_backgrounds = False
                 norm_low_res = [0, 255]
                 norm_low_res_flag = False
@@ -126,9 +123,6 @@ class ExportXMLConfig(object):
             str_array.append('   <to_peak_pixels>' + str(data_peak[1]) + '</to_peak_pixels>\n')
             str_array.append('   <peak_discrete_selection>N/A</peak_discrete_selection>\n')
             str_array.append('   <background_flag>' + str(data_back_flag) + '</background_flag>\n')
-            str_array.append(
-                '   <functional_background>' + str(data_functional_background) + '</functional_background>\n'
-            )
             str_array.append('   <two_backgrounds>' + str(data_two_backgrounds) + '</two_backgrounds>\n')
             str_array.append('   <back_roi1_from>' + str(data_back[0]) + '</back_roi1_from>\n')
             str_array.append('   <back_roi1_to>' + str(data_back[1]) + '</back_roi1_to>\n')
@@ -166,9 +160,6 @@ class ExportXMLConfig(object):
             str_array.append('   <norm_from_peak_pixels>' + str(norm_peak[0]) + '</norm_from_peak_pixels>\n')
             str_array.append('   <norm_to_peak_pixels>' + str(norm_peak[1]) + '</norm_to_peak_pixels>\n')
             str_array.append('   <norm_background_flag>' + str(norm_back_flag) + '</norm_background_flag>\n')
-            str_array.append(
-                '   <norm_functional_background>' + str(norm_functional_background) + '</norm_functional_background>\n'
-            )
             str_array.append('   <norm_two_backgrounds>' + str(norm_two_backgrounds) + '</norm_two_backgrounds>\n')
             str_array.append('   <norm_from_back_pixels>' + str(norm_back[0]) + '</norm_from_back_pixels>\n')
             str_array.append('   <norm_to_back_pixels>' + str(norm_back[1]) + '</norm_to_back_pixels>\n')

--- a/RefRed/configuration/load_reduction_table_from_lconfigdataset.py
+++ b/RefRed/configuration/load_reduction_table_from_lconfigdataset.py
@@ -100,7 +100,6 @@ class LoadReductionTableFromLConfigDataSet(object):
             back2_1 = int(lconfig.data_back2[0])
             back2_2 = int(lconfig.data_back2[1])
             back_flag = lconfig.data_back_flag
-            functional_background = lconfig.data_functional_background
             two_backgrounds = lconfig.data_two_backgrounds
             low_res1 = int(lconfig.data_low_res[0])
             low_res2 = int(lconfig.data_low_res[1])
@@ -115,7 +114,6 @@ class LoadReductionTableFromLConfigDataSet(object):
             back2_1 = int(lconfig.norm_back2[0])
             back2_2 = int(lconfig.norm_back2[1])
             back_flag = lconfig.norm_back_flag
-            functional_background = lconfig.norm_functional_background
             two_backgrounds = lconfig.norm_two_backgrounds
             low_res1 = int(lconfig.norm_low_res[0])
             low_res2 = int(lconfig.norm_low_res[1])
@@ -130,7 +128,6 @@ class LoadReductionTableFromLConfigDataSet(object):
         lrdata.back = [back1_1, back1_2]
         lrdata.back2 = [back2_1, back2_2]
         lrdata.back_flag = back_flag
-        lrdata.functional_background = functional_background
         lrdata.two_backgrounds = two_backgrounds
         lrdata.low_res = [low_res1, low_res2]
         lrdata.low_res_flag = low_res_flag

--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -206,7 +206,6 @@ class LoadingConfiguration(object):
 
         # background settings for reflectivity data
         iMetadata.data_back_flag = get_item_boolean("background_flag", default=True)
-        iMetadata.data_functional_background = get_item_boolean("functional_background", default=False)
         iMetadata.data_two_backgrounds = get_item_boolean("two_backgrounds", default=False)
 
         _low_res_flag = str2bool(self.getNodeValue(node, 'x_range_flag'))
@@ -258,7 +257,6 @@ class LoadingConfiguration(object):
 
         # background settings for normalization data
         iMetadata.norm_back_flag = get_item_boolean("norm_background_flag", default=True)
-        iMetadata.norm_functional_background = get_item_boolean("norm_functional_background", default=False)
         iMetadata.norm_two_backgrounds = get_item_boolean("norm_two_backgrounds", default=False)
 
         _low_res_flag = str2bool(self.getNodeValue(node, 'norm_x_range_flag'))

--- a/RefRed/interfaces/background_settings.ui
+++ b/RefRed/interfaces/background_settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>260</width>
-    <height>160</height>
+    <height>101</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,10 +19,10 @@
   <widget class="QWidget" name="verticalLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>13</x>
-     <y>19</y>
+     <x>10</x>
+     <y>10</y>
      <width>241</width>
-     <height>131</height>
+     <height>81</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -50,40 +50,6 @@
       </item>
       <item>
        <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QCheckBox" name="functional_background">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fit the background region(s) with a linear function. Functional background is necessary when using two background regions. It is optional when using a single region. In that case, the background is estimated by simple averaging&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Use functional background</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>

--- a/RefRed/lconfigdataset.py
+++ b/RefRed/lconfigdataset.py
@@ -20,7 +20,6 @@ class LConfigDataset(object):
     data_back2: List[int] = [0, 0]  # lower and upper boundaries for the second background
     data_low_res = [50, 200]
     data_back_flag: bool = True
-    data_functional_background: bool = False
     data_two_backgrounds: bool = False
     data_low_res_flag = True
     data_lambda_requested = -1
@@ -38,7 +37,6 @@ class LConfigDataset(object):
     norm_back = [0, 0]
     norm_back2: List[int] = [0, 0]  # lower and upper boundaries for the second background
     norm_back_flag: bool = True
-    norm_functional_background: bool = False
     norm_two_backgrounds: bool = False
 
     norm_low_res = [50, 200]

--- a/RefRed/preview_config/preview_config.py
+++ b/RefRed/preview_config/preview_config.py
@@ -16,7 +16,6 @@ class PreviewConfig(QtWidgets.QMainWindow):
         "to_peak_pixels",
         "peak_discrete_selection",
         "background_flag",
-        "functional_background",
         "two_backgrounds",
         "back_roi1_from",
         "back_roi1_to",
@@ -38,7 +37,6 @@ class PreviewConfig(QtWidgets.QMainWindow):
         "norm_from_peak_pixels",
         "norm_to_peak_pixels",
         "norm_background_flag",
-        "norm_functional_background",
         "norm_two_backgrounds",
         "norm_from_back_pixels",
         "norm_to_back_pixels",
@@ -61,9 +59,7 @@ class PreviewConfig(QtWidgets.QMainWindow):
     # may have default values. This way we will load configuration files missing these entries
     # and preview them with the default values.
     data_name_defaults = {
-        "functional_background": False,
         "two_backgrounds": False,
-        "norm_functional_background": False,
         "norm_two_backgrounds": False,
     }
 

--- a/RefRed/reduction/individual_reduction_settings_handler.py
+++ b/RefRed/reduction/individual_reduction_settings_handler.py
@@ -67,7 +67,7 @@ class IndividualReductionSettingsHandler(object):
             data_peak_range=self._data_peak_range,
             subtract_background=self.data.back_flag,
             two_backgrounds=self.data.two_backgrounds,  # should we use both background regions?
-            functional_background=self.data.functional_background,
+            functional_background=self.data.two_backgrounds,  # should have same value as `two_backgrounds`
             background_roi=self._data_back_range,
             data_x_range_flag=self._data_low_res_flag,
             data_x_range=self._data_low_res_range,

--- a/RefRed/reduction/live_reduction_handler.py
+++ b/RefRed/reduction/live_reduction_handler.py
@@ -87,7 +87,7 @@ class LiveReductionHandler(object):
                     template_data,
                     info=True,
                     normalize=reduction_pars['apply_normalization'],
-                    functional_background=reduction_pars['functional_background'],
+                    functional_background=reduction_pars['two_backgrounds'],
                 )
                 self.save_reduction(row_index, refl=[q, r, dr], info=info)
             except:


### PR DESCRIPTION
# Short description of the changes:
Remove functional background from background settings. The backend `lr_reduction` will make the decision about functional background depending on whether the option to use two backgrounds is active or not.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Open the background settings in the UI and check that the functional background is removed and the remaining options work as before.

# References
[Defect 4326: [REFRED] Eliminate "functional background" from the background settings](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4326)
