### PR TITLE
Remove warnings about invalid background range

### DIFF
--- a/RefRed/interfaces/plot2d_dialog_refl_interface.ui
+++ b/RefRed/interfaces/plot2d_dialog_refl_interface.ui
@@ -661,20 +661,6 @@
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QLabel" name="plot2dPeakFromError">
-               <property name="font">
-                <font>
-                 <pointsize>20</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>*</string>
-               </property>
-              </widget>
-             </item>
             </layout>
            </item>
            <item>
@@ -750,20 +736,6 @@
                </property>
                <property name="value">
                 <number>255</number>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="plot2dPeakToError">
-               <property name="font">
-                <font>
-                 <pointsize>20</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>*</string>
                </property>
               </widget>
              </item>
@@ -857,20 +829,6 @@
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QLabel" name="plot2dBackFromError">
-               <property name="font">
-                <font>
-                 <pointsize>20</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>*</string>
-               </property>
-              </widget>
-             </item>
             </layout>
            </item>
            <item>
@@ -946,20 +904,6 @@
                </property>
                <property name="value">
                 <number>255</number>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="plot2dBackToError">
-               <property name="font">
-                <font>
-                 <pointsize>20</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>*</string>
                </property>
               </widget>
              </item>
@@ -1056,20 +1000,6 @@
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QLabel" name="plot2dBack2FromError">
-               <property name="font">
-                <font>
-                 <pointsize>20</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>*</string>
-               </property>
-              </widget>
-             </item>
             </layout>
            </item>
            <item>
@@ -1151,20 +1081,6 @@
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QLabel" name="plot2dBack2ToError">
-               <property name="font">
-                <font>
-                 <pointsize>20</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>*</string>
-               </property>
-              </widget>
-             </item>
             </layout>
            </item>
           </layout>
@@ -1185,19 +1101,6 @@
          </property>
          <property name="autoDefault">
           <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="error_label">
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
-         </property>
-         <property name="text">
-          <string>(*) INVALID SELECTION</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>

--- a/RefRed/interfaces/plot_dialog_refl_interface.ui
+++ b/RefRed/interfaces/plot_dialog_refl_interface.ui
@@ -128,32 +128,6 @@
                    </property>
                   </widget>
                  </item>
-                 <item>
-                  <widget class="QLabel" name="plotPeakFromLabel">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                  </widget>
-                 </item>
                 </layout>
                </item>
                <item>
@@ -229,32 +203,6 @@
                    </property>
                    <property name="value">
                     <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="plotPeakToLabel">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
                    </property>
                   </widget>
                  </item>
@@ -348,29 +296,6 @@
                    </property>
                   </widget>
                  </item>
-                 <item>
-                  <widget class="QLabel" name="plotBackFromLabel">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                  </widget>
-                 </item>
                 </layout>
                </item>
                <item>
@@ -446,26 +371,6 @@
                    </property>
                    <property name="value">
                     <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="plotBackToLabel">
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
                    </property>
                   </widget>
                  </item>
@@ -562,29 +467,6 @@
                    </property>
                   </widget>
                  </item>
-                 <item>
-                  <widget class="QLabel" name="plotBack2FromLabel">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                  </widget>
-                 </item>
                 </layout>
                </item>
                <item>
@@ -666,29 +548,6 @@
                    </property>
                   </widget>
                  </item>
-                 <item>
-                  <widget class="QLabel" name="plotBack2ToLabel">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <pointsize>20</pointsize>
-                     <weight>75</weight>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>*</string>
-                   </property>
-                  </widget>
-                 </item>
                 </layout>
                </item>
               </layout>
@@ -731,16 +590,6 @@
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="invalid_selection_label">
-     <property name="text">
-      <string>(*)    INVALID SELECTION</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
     </widget>
    </item>
   </layout>

--- a/RefRed/plot/popup_plot_1d.py
+++ b/RefRed/plot/popup_plot_1d.py
@@ -5,8 +5,6 @@ import os
 from typing import Optional
 
 # third-party imports
-from qtpy.QtCore import Qt  # type: ignore
-from qtpy.QtGui import QPalette
 from qtpy.QtWidgets import QDialog, QFileDialog
 
 # package imports
@@ -64,7 +62,6 @@ class PopupPlot1d(QDialog):
         self.ui = load_ui("plot_dialog_refl_interface.ui", self)
 
         self.setWindowTitle("Counts vs Y pixel")
-        self.hide_and_format_invalid_widgets()
 
         self.ui.plot_counts_vs_pixel.leaveFigure.connect(self.leave_plot_counts_vs_pixel)
         self.ui.plot_counts_vs_pixel.toolbar.homeClicked.connect(self.home_plot_counts_vs_pixel)
@@ -126,30 +123,6 @@ class PopupPlot1d(QDialog):
         self.ui.plot_counts_vs_pixel.canvas.ax.set_xlim([ymin, ymax])
         self.ui.plot_counts_vs_pixel.draw()
 
-    def hide_and_format_invalid_widgets(self):
-        palette = QPalette()
-        palette.setColor(QPalette.Foreground, Qt.red)
-        self.ui.plotPeakFromLabel.setVisible(False)
-        self.ui.plotPeakFromLabel.setPalette(palette)
-
-        self.ui.plotPeakToLabel.setVisible(False)
-        self.ui.plotPeakToLabel.setPalette(palette)
-
-        self.ui.plotBackFromLabel.setVisible(False)
-        self.ui.plotBackFromLabel.setPalette(palette)
-
-        self.ui.plotBackToLabel.setVisible(False)
-        self.ui.plotBackToLabel.setPalette(palette)
-
-        self.ui.plotBack2FromLabel.setVisible(False)
-        self.ui.plotBack2FromLabel.setPalette(palette)
-
-        self.ui.plotBack2ToLabel.setVisible(False)
-        self.ui.plotBack2ToLabel.setPalette(palette)
-
-        self.ui.invalid_selection_label.setVisible(False)
-        self.ui.invalid_selection_label.setPalette(palette)
-
     def sort_peak_back_input(self):
         peak1 = self.ui.plotPeakFromSpinBox.value()
         peak2 = self.ui.plotPeakToSpinBox.value()
@@ -171,36 +144,6 @@ class PopupPlot1d(QDialog):
         if back_min != back1:
             self.ui.plotBack2FromSpinBox.setValue(back2)
             self.ui.plotBack2ToSpinBox.setValue(back1)
-
-    def check_peak_back_input_validity(self):
-        peak1 = self.ui.plotPeakFromSpinBox.value()
-        peak2 = self.ui.plotPeakToSpinBox.value()
-
-        back1 = self.ui.plotBackFromSpinBox.value()
-        back2 = self.ui.plotBackToSpinBox.value()
-
-        _show_widgets_1 = False
-        _show_widgets_2 = False
-        second_background_boundaries_unsorted = False
-
-        if backgrounds_settings[self.data_type].subtract_background:
-            if back1 > peak1:
-                _show_widgets_1 = True
-            if back2 < peak2:
-                _show_widgets_2 = True
-            if backgrounds_settings[self.data_type].two_backgrounds:
-                if self.data.back2[0] > self.data.back2[1]:
-                    second_background_boundaries_unsorted = True
-
-        self.ui.plotPeakFromLabel.setVisible(_show_widgets_1)
-        self.ui.plotBackFromLabel.setVisible(_show_widgets_1)
-        self.ui.plotBack2FromLabel.setVisible(second_background_boundaries_unsorted)
-
-        self.ui.plotPeakToLabel.setVisible(_show_widgets_2)
-        self.ui.plotBackToLabel.setVisible(_show_widgets_2)
-        self.ui.plotBack2ToLabel.setVisible(second_background_boundaries_unsorted)
-
-        self.ui.invalid_selection_label.setVisible(_show_widgets_1 or _show_widgets_2)
 
     def reset_max_ui_value(self):
         self.ui.plotPeakFromSpinBox.setMaximum(255)
@@ -311,12 +254,10 @@ class PopupPlot1d(QDialog):
 
     def plot_back_flag_clicked(self, _):
         self.update_plots()
-        self.check_peak_back_input_validity()
 
     def set_peak_value(self, peak1, peak2):
         self.ui.plotPeakFromSpinBox.setValue(peak1)
         self.ui.plotPeakToSpinBox.setValue(peak2)
-        self.check_peak_back_input_validity()
 
     def set_back_value(
         self,
@@ -328,12 +269,10 @@ class PopupPlot1d(QDialog):
         assert boundary_from <= boundary_to
         getattr(self.ui, spinbox_from).setValue(boundary_from)
         getattr(self.ui, spinbox_to).setValue(boundary_to)
-        self.check_peak_back_input_validity()
 
     def act_upon_changed_boundaries(self):
         r"""Actions after User changes any boundary value (peak or background) in the QSpinBox widgets"""
         self.sort_peak_back_input()
-        self.check_peak_back_input_validity()
         self.update_plots()
 
     def plot_peak_from_spinbox_value_changed(self):

--- a/RefRed/plot/popup_plot_2d.py
+++ b/RefRed/plot/popup_plot_2d.py
@@ -3,8 +3,6 @@ from pathlib import Path
 import os
 
 # third-party imports
-from qtpy.QtCore import Qt  # type: ignore
-from qtpy.QtGui import QPalette
 from qtpy.QtWidgets import QDialog, QFileDialog
 
 # package imports
@@ -255,37 +253,6 @@ class PopupPlot2d(QDialog):
         return self.retrieveLowRes() + self.retrievePeakBack()
 
     def init_gui(self):
-        palette = QPalette()
-        palette.setColor(QPalette.Foreground, Qt.red)
-        r"""
-        if self.data.new_detector_geometry_flag:
-            yrange = [0, 303]
-            xrange = [0, 255]
-        else:
-            yrange = [0, 255]
-            xrange = [0, 303]
-        """
-        self.ui.error_label.setVisible(False)
-        self.ui.error_label.setPalette(palette)
-
-        self.ui.plot2dPeakFromError.setVisible(False)
-        self.ui.plot2dPeakFromError.setPalette(palette)
-
-        self.ui.plot2dPeakToError.setVisible(False)
-        self.ui.plot2dPeakToError.setPalette(palette)
-
-        self.ui.plot2dBackFromError.setVisible(False)
-        self.ui.plot2dBackFromError.setPalette(palette)
-
-        self.ui.plot2dBackToError.setVisible(False)
-        self.ui.plot2dBackToError.setPalette(palette)
-
-        self.ui.plot2dBack2FromError.setVisible(False)
-        self.ui.plot2dBack2FromError.setPalette(palette)
-
-        self.ui.plot2dBack2ToError.setVisible(False)
-        self.ui.plot2dBack2ToError.setPalette(palette)
-
         # enable/disable background spinboxes based on the background settings
         self.background_settings.control_spinboxes_visibility(
             self.ui,
@@ -351,7 +318,6 @@ class PopupPlot2d(QDialog):
             first_background=("plot2dBackFromValue", "plot2dBackToValue"),
             second_background=("plot2dBack2FromValue", "plot2dBack2ToValue"),
         )
-        self.check_peak_back_input_validity()
         self.update_plots()
 
     def activate_or_not_low_res_widgets(self, low_res_flag):
@@ -389,11 +355,11 @@ class PopupPlot2d(QDialog):
         self.update_detector_tab_plot()
 
     def manual_input_peak1(self):
-        self.sort_and_check_widgets()
+        self.sort_peak_back_input()
         self.update_plots()
 
     def manual_input_peak2(self):
-        self.sort_and_check_widgets()
+        self.sort_peak_back_input()
         self.update_plots()
 
     def plot2d_peak_from_spinbox_value_changed(self):
@@ -413,7 +379,7 @@ class PopupPlot2d(QDialog):
             self.manual_input_peak2()
 
     def manual_input_background(self):
-        self.sort_and_check_widgets()
+        self.sort_peak_back_input()
         self.update_plots()
 
     def display_background_settings(self, *args, **kwargs):
@@ -450,40 +416,6 @@ class PopupPlot2d(QDialog):
         """
         if self.spinbox_observer.quantum_change(self.ui.plot2dBack2ToValue):
             self.manual_input_background()
-
-    def sort_and_check_widgets(self):
-        self.sort_peak_back_input()
-        self.check_peak_back_input_validity()
-
-    def check_peak_back_input_validity(self):
-        peak1 = self.ui.plot2dPeakFromSpinBox.value()
-        peak2 = self.ui.plot2dPeakToSpinBox.value()
-        back1 = self.ui.plot2dBackFromValue.value()
-        back2 = self.ui.plot2dBackToValue.value()
-
-        _show_widgets_1 = False
-        _show_widgets_2 = False
-        second_background_boundaries_unsorted = False
-
-        if self.background_settings.subtract_background:
-            if back1 > peak1:
-                _show_widgets_1 = True
-            if back2 < peak2:
-                _show_widgets_2 = True
-            if self.background_settings.two_backgrounds:
-                if self.data.back2[0] > self.data.back2[1]:
-                    second_background_boundaries_unsorted = True
-
-        self.ui.plot2dPeakFromError.setVisible(_show_widgets_1)
-        self.ui.plot2dBackFromError.setVisible(_show_widgets_1)
-        self.ui.plot2dBack2FromError.setVisible(second_background_boundaries_unsorted)
-
-        self.ui.plot2dPeakToError.setVisible(_show_widgets_2)
-        self.ui.plot2dBackToError.setVisible(_show_widgets_2)
-        self.ui.plot2dBack2ToError.setVisible(second_background_boundaries_unsorted)
-
-        any_error = _show_widgets_1 or _show_widgets_2 or second_background_boundaries_unsorted
-        self.ui.error_label.setVisible(any_error)
 
     def manual_input_of_low_res_field(self):
         value1 = self.ui.low_res1.value()


### PR DESCRIPTION
# Short description of the changes:
The user is shown warnings when the peak range is not inside the background range. However, these warnings are obsolete as it is now valid to to define one or two background regions away from the peak range.

This PR removes the warnings shown here (red stars and text "INVALID SELECTION"):
![Screenshot from 2024-03-20 10-42-54](https://github.com/neutrons/RefRed/assets/6989921/70ba5099-3f5d-4307-a68e-9346c036ad55)

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Test changing peak and background ranges in the popup plots that appear when double-clicking either the Y vs TOF plot or the counts vs Y plot. Everything should work as before, except that there should be no red warnings about "INVALID SELECTION" shown.



# References
[Defect 4326: [REFRED] Eliminate "functional background" from the background settings](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4326)
