### PR TITLE
Common entry-widget for MainGui and SFCalculatorUI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,8 +1,0 @@
-<!-- remove if not associated with an issue -->
-Fixes #
-
-## Description
-
-## Work Done
-
-See [CONTRIBUTING.rst](CONTRIBUTING.rst>).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,20 @@
 <!-- description here. -->
 
 # Manual test for the reviewer
-<!-- Instructions for testing here. -->
+Before running the manual tests, install the conda environment and install the source in editable mode
+```bash
+> conda env create --solver libmamba --name refred-dev --file ./environment.yml
+> conda activate refred-dev
+(refred-dev)> pip install -e .
+```
+Start RefRed GUI
+```bash
+(refred-dev)> PYTHONPATH=$(pwd):$PYTHONPATH ./scripts/start_refred.py
+```
+Or run tests
+```bash
+(refred-dev)> pytest test/unit/RefRed/test_main.py
+```
 
 # Check list for the reviewer
 - [ ] I have verified the proposed changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+# References
+- EWM #
+<!-- Links to related issues or pull requests -->
+
+# Description of the changes:
+<!-- description here. -->
+
+# Manual test for the reviewer
+<!-- Instructions for testing here. -->
+
+# Check list for the reviewer
+- [ ] I have verified the proposed changes
+- [ ] Author included tests for the proposed changes
+- [ ] best software practices
+    + [ ] clearly named variables (better to be verbose in variable names)
+    + [ ] code comments explaining the intent of code blocks
+    + [ ] new functions and classes detailed docstrings, parameters documented
+- [ ] All tests are passing
+- [ ] Documentation is up to date
+
+# Check list for the author
+- [ ] I have added tests for my changes
+- [ ] I have updated the documentation accordingly
+- [ ] I included a link to IBM EWM Story or Defect

--- a/RefRed/configuration/loading_configuration.py
+++ b/RefRed/configuration/loading_configuration.py
@@ -180,7 +180,7 @@ class LoadingConfiguration(object):
         o_scaling_factor_widget.set_enabled(status=scaling_factor_flag)
 
         use_dead_time = str2bool(self.getNodeValue(node_0, 'dead_time_correction'))
-        self.parent.ui.deadtime_checkbox.setChecked(use_dead_time)
+        self.parent.ui.deadtime_entry.applyCheckBox.setChecked(use_dead_time)
 
     def getMetadataObject(self, node) -> LConfigDataset:
         r"""Populate an instance of type LConfigDataset using the information contained in one of the

--- a/RefRed/initialization/gui.py
+++ b/RefRed/initialization/gui.py
@@ -53,13 +53,7 @@ class Gui(object):
 
         # This is the angle offset box, which is no longer needed
         # but kept for advanced usage
-        self.parent.ui.groupBox_4.setVisible(False)
-
-        # This is the TOF steps, which we also don't need at the moment
-        self.parent.ui.eventTofBins.setVisible(False)
-        self.parent.ui.label_33.setVisible(False)
-        self.parent.ui.label_29.setVisible(False)
-
+        self.parent.ui.AngleOffsetGroupBox.setVisible(False)
         self.parent.ui.sf_button.setChecked(True)
 
         # Select the `DATA` tab as the currently active one

--- a/RefRed/interfaces/deadtime_entry.py
+++ b/RefRed/interfaces/deadtime_entry.py
@@ -1,0 +1,41 @@
+# third party imports
+from qtpy.QtWidgets import QGroupBox, QHBoxLayout, QCheckBox, QPushButton
+
+
+class DeadTimeEntryPoint(QGroupBox):
+    def __init__(self, title='Dead Time Correction'):
+        super().__init__(title)
+        self.initUI()
+
+    def initUI(self):
+        # Set the stylesheet for the group box to have a border
+        self.setStyleSheet(
+            "QGroupBox {"
+            "  border: 1px solid gray;"
+            "  border-radius: 5px;"
+            "  margin-top: 1ex;"  # space above the group box
+            "} "
+            "QGroupBox::title {"
+            "  subcontrol-origin: margin;"
+            "  subcontrol-position: top center;"  # align the title to the center
+            "  padding: 0 3px;"
+            "}"
+        )
+
+        self.applyCheckBox = QCheckBox('Apply', self)
+        self.applyCheckBox.stateChanged.connect(self.toggleSettingsButton)
+        self.settingsButton = QPushButton('Settings', self)
+        self.settingsButton.setEnabled(self.applyCheckBox.isChecked())  # enabled if we use the correction
+
+        # Create a horizontal layout for the checkbox and settings button
+        hbox = QHBoxLayout()
+        hbox.addWidget(self.applyCheckBox)
+        hbox.addWidget(self.settingsButton)
+        hbox.addStretch(1)  # This adds a stretchable space after the button (optional)
+
+        # Set the layout for the group box
+        self.setLayout(hbox)
+
+    def toggleSettingsButton(self, state):
+        # Enable the settings button if the checkbox is checked, disable otherwise
+        self.settingsButton.setEnabled(state)

--- a/RefRed/interfaces/deadtime_settings.py
+++ b/RefRed/interfaces/deadtime_settings.py
@@ -13,7 +13,7 @@ class DeadTimeSettingsView(QDialog):
         self.ui = load_ui(ui_filename="deadtime_settings.ui", baseinstance=self)
         self.options = self.get_state_from_form()
 
-    def set_state(self, apply_correction, paralyzable, dead_time, tof_step):
+    def set_state(self, paralyzable, dead_time, tof_step):
         """
         Store options and populate the form
         :param apply_correction: If True, dead time correction will be applied
@@ -21,7 +21,6 @@ class DeadTimeSettingsView(QDialog):
         :param dead_time: Value of the dead time in micro second
         :param tof_step: TOF binning in micro second
         """
-        self.ui.apply_correction.setChecked(apply_correction)
         self.ui.use_paralyzable.setChecked(paralyzable)
         self.ui.dead_time_value.setValue(dead_time)
         self.ui.dead_time_tof.setValue(tof_step)
@@ -32,7 +31,6 @@ class DeadTimeSettingsView(QDialog):
         Read the options from the form.
         """
         options = {}
-        options['apply_correction'] = self.ui.apply_correction.isChecked()
         options['paralyzable'] = self.ui.use_paralyzable.isChecked()
         options['dead_time'] = self.ui.dead_time_value.value()
         options['tof_step'] = self.ui.dead_time_tof.value()

--- a/RefRed/interfaces/deadtime_settings.ui
+++ b/RefRed/interfaces/deadtime_settings.ui
@@ -9,9 +9,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>472</width>
-    <height>214</height>
+    <width>428</width>
+    <height>150</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>439</width>
+    <height>150</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Dead Time Settings</string>
@@ -22,43 +34,6 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QCheckBox" name="apply_correction">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable/Disable background subtraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Apply dead time correction</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
@@ -73,6 +48,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_3">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use two background regions to estimate the background under the peak&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
@@ -183,8 +164,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>130</width>
-           <height>16777215</height>
+           <width>0</width>
+           <height>100</height>
           </size>
          </property>
          <property name="decimals">
@@ -202,19 +183,6 @@
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
      </item>
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/RefRed/interfaces/refred_main_interface.ui
+++ b/RefRed/interfaces/refred_main_interface.ui
@@ -38,8 +38,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>1544</width>
-         <height>1317</height>
+         <width>1540</width>
+         <height>1319</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_68">
@@ -603,6 +603,15 @@
                                </color>
                               </brush>
                              </colorrole>
+                             <colorrole role="PlaceholderText">
+                              <brush brushstyle="NoBrush">
+                               <color alpha="128">
+                                <red>0</red>
+                                <green>0</green>
+                                <blue>0</blue>
+                               </color>
+                              </brush>
+                             </colorrole>
                             </active>
                             <inactive>
                              <colorrole role="WindowText">
@@ -734,6 +743,15 @@
                              <colorrole role="ToolTipText">
                               <brush brushstyle="SolidPattern">
                                <color alpha="255">
+                                <red>0</red>
+                                <green>0</green>
+                                <blue>0</blue>
+                               </color>
+                              </brush>
+                             </colorrole>
+                             <colorrole role="PlaceholderText">
+                              <brush brushstyle="NoBrush">
+                               <color alpha="128">
                                 <red>0</red>
                                 <green>0</green>
                                 <blue>0</blue>
@@ -877,6 +895,15 @@
                                </color>
                               </brush>
                              </colorrole>
+                             <colorrole role="PlaceholderText">
+                              <brush brushstyle="NoBrush">
+                               <color alpha="128">
+                                <red>0</red>
+                                <green>0</green>
+                                <blue>0</blue>
+                               </color>
+                              </brush>
+                             </colorrole>
                             </disabled>
                            </palette>
                           </property>
@@ -892,142 +919,144 @@
                           </property>
                           <layout class="QVBoxLayout" name="verticalLayout_15">
                            <item>
-                            <widget class="QFrame" name="frame_4">
-                             <property name="frameShape">
-                              <enum>QFrame::StyledPanel</enum>
-                             </property>
-                             <property name="frameShadow">
-                              <enum>QFrame::Raised</enum>
-                             </property>
-                             <layout class="QHBoxLayout" name="horizontalLayout_17">
-                              <item>
-                               <layout class="QGridLayout" name="gridLayout_6">
-                                <item row="0" column="0">
-                                 <widget class="QLabel" name="label_29">
-                                  <property name="sizePolicy">
-                                   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                   </sizepolicy>
-                                  </property>
-                                  <property name="toolTip">
-                                   <string>The number of bins for the Time of Flight channels</string>
-                                  </property>
-                                  <property name="text">
-                                   <string>TOF bins</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item row="0" column="1">
-                                 <widget class="QSpinBox" name="eventTofBins">
-                                  <property name="minimumSize">
-                                   <size>
-                                    <width>100</width>
-                                    <height>0</height>
-                                   </size>
-                                  </property>
-                                  <property name="toolTip">
-                                   <string>The number of bins for the Time of Flight channels</string>
-                                  </property>
-                                  <property name="minimum">
-                                   <number>5</number>
-                                  </property>
-                                  <property name="maximum">
-                                   <number>200</number>
-                                  </property>
-                                  <property name="singleStep">
-                                   <number>5</number>
-                                  </property>
-                                  <property name="value">
-                                   <number>40</number>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item row="0" column="2">
-                                 <widget class="QLabel" name="label_33">
-                                  <property name="text">
-                                   <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;µs&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item row="1" column="0">
-                                 <widget class="QLabel" name="label_10">
-                                  <property name="minimumSize">
-                                   <size>
-                                    <width>70</width>
-                                    <height>0</height>
-                                   </size>
-                                  </property>
-                                  <property name="maximumSize">
-                                   <size>
-                                    <width>70</width>
-                                    <height>16777215</height>
-                                   </size>
-                                  </property>
-                                  <property name="text">
-                                   <string>Q binning</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item row="1" column="1">
-                                 <widget class="QLineEdit" name="qStep">
-                                  <property name="maximumSize">
-                                   <size>
-                                    <width>100</width>
-                                    <height>16777215</height>
-                                   </size>
-                                  </property>
-                                  <property name="text">
-                                   <string>0.01</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item row="1" column="2">
-                                 <widget class="QLabel" name="label_11">
-                                  <property name="minimumSize">
-                                   <size>
-                                    <width>0</width>
-                                    <height>0</height>
-                                   </size>
-                                  </property>
-                                  <property name="maximumSize">
-                                   <size>
-                                    <width>16777215</width>
-                                    <height>16777215</height>
-                                   </size>
-                                  </property>
-                                  <property name="text">
-                                   <string>ΔQ/Q</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item row="2" column="0">
-                                 <widget class="QCheckBox" name="deadtime_checkbox">
-                                  <property name="text">
-                                   <string>Use dead time correction</string>
-                                  </property>
-                                  <property name="checked">
-                                   <bool>true</bool>
-                                  </property>
-                                 </widget>
-                                </item>
-                               </layout>
-                              </item>
-                             </layout>
-                            </widget>
+                            <layout class="QVBoxLayout" name="verticalLayout_37">
+                             <item>
+                              <layout class="QHBoxLayout" name="horizontalLayout_18">
+                               <item>
+                                <widget class="QLabel" name="eventTofBinsTitleLabel">
+                                 <property name="text">
+                                  <string>TOF bins</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QSpinBox" name="eventTofBins">
+                                 <property name="minimum">
+                                  <number>5</number>
+                                 </property>
+                                 <property name="maximum">
+                                  <number>200</number>
+                                 </property>
+                                 <property name="singleStep">
+                                  <number>5</number>
+                                 </property>
+                                 <property name="value">
+                                  <number>40</number>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QLabel" name="eventTofBinsUnitsLabel">
+                                 <property name="text">
+                                  <string>µs</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <spacer name="horizontalSpacer_6">
+                                 <property name="orientation">
+                                  <enum>Qt::Horizontal</enum>
+                                 </property>
+                                 <property name="sizeHint" stdset="0">
+                                  <size>
+                                   <width>40</width>
+                                   <height>20</height>
+                                  </size>
+                                 </property>
+                                </spacer>
+                               </item>
+                              </layout>
+                             </item>
+                             <item>
+                              <layout class="QHBoxLayout" name="horizontalLayout_34">
+                               <item>
+                                <widget class="QLabel" name="label_8">
+                                 <property name="text">
+                                  <string>Q binning</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QLineEdit" name="qStep">
+                                 <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                   <horstretch>0</horstretch>
+                                   <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                 </property>
+                                 <property name="maximumSize">
+                                  <size>
+                                   <width>100</width>
+                                   <height>16777215</height>
+                                  </size>
+                                 </property>
+                                 <property name="text">
+                                  <string>0.01</string>
+                                 </property>
+                                 <property name="maxLength">
+                                  <number>32767</number>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QLabel" name="label_9">
+                                 <property name="text">
+                                  <string>ΔQ/Q</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <spacer name="horizontalSpacer_8">
+                                 <property name="orientation">
+                                  <enum>Qt::Horizontal</enum>
+                                 </property>
+                                 <property name="sizeHint" stdset="0">
+                                  <size>
+                                   <width>40</width>
+                                   <height>20</height>
+                                  </size>
+                                 </property>
+                                </spacer>
+                               </item>
+                              </layout>
+                             </item>
+                             <item>
+                              <layout class="QHBoxLayout" name="horizontalLayout_40">
+                               <item>
+                                <widget class="DeadTimeEntryPoint" name="deadtime_entry">
+                                 <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                   <horstretch>0</horstretch>
+                                   <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                 </property>
+                                 <property name="title">
+                                  <string>Dead Time Correction</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <spacer name="horizontalSpacer_9">
+                                 <property name="orientation">
+                                  <enum>Qt::Horizontal</enum>
+                                 </property>
+                                 <property name="sizeHint" stdset="0">
+                                  <size>
+                                   <width>40</width>
+                                   <height>20</height>
+                                  </size>
+                                 </property>
+                                </spacer>
+                               </item>
+                              </layout>
+                             </item>
+                            </layout>
                            </item>
                           </layout>
                          </widget>
                         </item>
                         <item>
-                         <layout class="QVBoxLayout" name="verticalLayout_10"/>
-                        </item>
-                        <item>
-                         <widget class="QGroupBox" name="groupBox_4">
+                         <widget class="QGroupBox" name="AngleOffsetGroupBox">
                           <property name="maximumSize">
                            <size>
                             <width>16777215</width>
@@ -1979,11 +2008,29 @@ p, li { white-space: pre-wrap; }
                                          </color>
                                         </brush>
                                        </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>0</red>
+                                          <green>255</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
                                       </active>
                                       <inactive>
                                        <colorrole role="Text">
                                         <brush brushstyle="SolidPattern">
                                          <color alpha="255">
+                                          <red>0</red>
+                                          <green>255</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
                                           <red>0</red>
                                           <green>255</green>
                                           <blue>0</blue>
@@ -1998,6 +2045,15 @@ p, li { white-space: pre-wrap; }
                                           <red>190</red>
                                           <green>190</green>
                                           <blue>190</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>0</red>
+                                          <green>255</green>
+                                          <blue>0</blue>
                                          </color>
                                         </brush>
                                        </colorrole>
@@ -2023,11 +2079,29 @@ p, li { white-space: pre-wrap; }
                                          </color>
                                         </brush>
                                        </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>0</red>
+                                          <green>255</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
                                       </active>
                                       <inactive>
                                        <colorrole role="Text">
                                         <brush brushstyle="SolidPattern">
                                          <color alpha="255">
+                                          <red>0</red>
+                                          <green>255</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
                                           <red>0</red>
                                           <green>255</green>
                                           <blue>0</blue>
@@ -2042,6 +2116,15 @@ p, li { white-space: pre-wrap; }
                                           <red>190</red>
                                           <green>190</green>
                                           <blue>190</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>0</red>
+                                          <green>255</green>
+                                          <blue>0</blue>
                                          </color>
                                         </brush>
                                        </colorrole>
@@ -2129,11 +2212,29 @@ p, li { white-space: pre-wrap; }
                                          </color>
                                         </brush>
                                        </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>15</green>
+                                          <blue>29</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
                                       </active>
                                       <inactive>
                                        <colorrole role="Text">
                                         <brush brushstyle="SolidPattern">
                                          <color alpha="255">
+                                          <red>255</red>
+                                          <green>15</green>
+                                          <blue>29</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
                                           <red>255</red>
                                           <green>15</green>
                                           <blue>29</blue>
@@ -2148,6 +2249,15 @@ p, li { white-space: pre-wrap; }
                                           <red>190</red>
                                           <green>190</green>
                                           <blue>190</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>15</green>
+                                          <blue>29</blue>
                                          </color>
                                         </brush>
                                        </colorrole>
@@ -2173,11 +2283,29 @@ p, li { white-space: pre-wrap; }
                                          </color>
                                         </brush>
                                        </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>15</green>
+                                          <blue>29</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
                                       </active>
                                       <inactive>
                                        <colorrole role="Text">
                                         <brush brushstyle="SolidPattern">
                                          <color alpha="255">
+                                          <red>255</red>
+                                          <green>15</green>
+                                          <blue>29</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
                                           <red>255</red>
                                           <green>15</green>
                                           <blue>29</blue>
@@ -2192,6 +2320,15 @@ p, li { white-space: pre-wrap; }
                                           <red>190</red>
                                           <green>190</green>
                                           <blue>190</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>15</green>
+                                          <blue>29</blue>
                                          </color>
                                         </brush>
                                        </colorrole>
@@ -2282,11 +2419,29 @@ p, li { white-space: pre-wrap; }
                                          </color>
                                         </brush>
                                        </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>120</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
                                       </active>
                                       <inactive>
                                        <colorrole role="Text">
                                         <brush brushstyle="SolidPattern">
                                          <color alpha="255">
+                                          <red>255</red>
+                                          <green>120</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
                                           <red>255</red>
                                           <green>120</green>
                                           <blue>0</blue>
@@ -2301,6 +2456,15 @@ p, li { white-space: pre-wrap; }
                                           <red>190</red>
                                           <green>190</green>
                                           <blue>190</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>120</green>
+                                          <blue>0</blue>
                                          </color>
                                         </brush>
                                        </colorrole>
@@ -2329,11 +2493,29 @@ p, li { white-space: pre-wrap; }
                                          </color>
                                         </brush>
                                        </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>120</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
                                       </active>
                                       <inactive>
                                        <colorrole role="Text">
                                         <brush brushstyle="SolidPattern">
                                          <color alpha="255">
+                                          <red>255</red>
+                                          <green>120</green>
+                                          <blue>0</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
                                           <red>255</red>
                                           <green>120</green>
                                           <blue>0</blue>
@@ -2348,6 +2530,15 @@ p, li { white-space: pre-wrap; }
                                           <red>190</red>
                                           <green>190</green>
                                           <blue>190</blue>
+                                         </color>
+                                        </brush>
+                                       </colorrole>
+                                       <colorrole role="PlaceholderText">
+                                        <brush brushstyle="NoBrush">
+                                         <color alpha="128">
+                                          <red>255</red>
+                                          <green>120</green>
+                                          <blue>0</blue>
                                          </color>
                                         </brush>
                                        </colorrole>
@@ -2558,11 +2749,29 @@ p, li { white-space: pre-wrap; }
                                      </color>
                                     </brush>
                                    </colorrole>
+                                   <colorrole role="PlaceholderText">
+                                    <brush brushstyle="NoBrush">
+                                     <color alpha="128">
+                                      <red>0</red>
+                                      <green>0</green>
+                                      <blue>255</blue>
+                                     </color>
+                                    </brush>
+                                   </colorrole>
                                   </active>
                                   <inactive>
                                    <colorrole role="Text">
                                     <brush brushstyle="SolidPattern">
                                      <color alpha="255">
+                                      <red>0</red>
+                                      <green>0</green>
+                                      <blue>255</blue>
+                                     </color>
+                                    </brush>
+                                   </colorrole>
+                                   <colorrole role="PlaceholderText">
+                                    <brush brushstyle="NoBrush">
+                                     <color alpha="128">
                                       <red>0</red>
                                       <green>0</green>
                                       <blue>255</blue>
@@ -2577,6 +2786,15 @@ p, li { white-space: pre-wrap; }
                                       <red>118</red>
                                       <green>118</green>
                                       <blue>117</blue>
+                                     </color>
+                                    </brush>
+                                   </colorrole>
+                                   <colorrole role="PlaceholderText">
+                                    <brush brushstyle="NoBrush">
+                                     <color alpha="128">
+                                      <red>0</red>
+                                      <green>0</green>
+                                      <blue>255</blue>
                                      </color>
                                     </brush>
                                    </colorrole>
@@ -2631,11 +2849,29 @@ p, li { white-space: pre-wrap; }
                                      </color>
                                     </brush>
                                    </colorrole>
+                                   <colorrole role="PlaceholderText">
+                                    <brush brushstyle="NoBrush">
+                                     <color alpha="128">
+                                      <red>0</red>
+                                      <green>0</green>
+                                      <blue>255</blue>
+                                     </color>
+                                    </brush>
+                                   </colorrole>
                                   </active>
                                   <inactive>
                                    <colorrole role="Text">
                                     <brush brushstyle="SolidPattern">
                                      <color alpha="255">
+                                      <red>0</red>
+                                      <green>0</green>
+                                      <blue>255</blue>
+                                     </color>
+                                    </brush>
+                                   </colorrole>
+                                   <colorrole role="PlaceholderText">
+                                    <brush brushstyle="NoBrush">
+                                     <color alpha="128">
                                       <red>0</red>
                                       <green>0</green>
                                       <blue>255</blue>
@@ -2650,6 +2886,15 @@ p, li { white-space: pre-wrap; }
                                       <red>118</red>
                                       <green>118</green>
                                       <blue>117</blue>
+                                     </color>
+                                    </brush>
+                                   </colorrole>
+                                   <colorrole role="PlaceholderText">
+                                    <brush brushstyle="NoBrush">
+                                     <color alpha="128">
+                                      <red>0</red>
+                                      <green>0</green>
+                                      <blue>255</blue>
                                      </color>
                                     </brush>
                                    </colorrole>
@@ -2854,11 +3099,29 @@ p, li { white-space: pre-wrap; }
                                              </color>
                                             </brush>
                                            </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>0</red>
+                                              <green>255</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
                                           </active>
                                           <inactive>
                                            <colorrole role="Text">
                                             <brush brushstyle="SolidPattern">
                                              <color alpha="255">
+                                              <red>0</red>
+                                              <green>255</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
                                               <red>0</red>
                                               <green>255</green>
                                               <blue>0</blue>
@@ -2873,6 +3136,15 @@ p, li { white-space: pre-wrap; }
                                               <red>190</red>
                                               <green>190</green>
                                               <blue>190</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>0</red>
+                                              <green>255</green>
+                                              <blue>0</blue>
                                              </color>
                                             </brush>
                                            </colorrole>
@@ -2916,11 +3188,29 @@ p, li { white-space: pre-wrap; }
                                              </color>
                                             </brush>
                                            </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>0</red>
+                                              <green>255</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
                                           </active>
                                           <inactive>
                                            <colorrole role="Text">
                                             <brush brushstyle="SolidPattern">
                                              <color alpha="255">
+                                              <red>0</red>
+                                              <green>255</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
                                               <red>0</red>
                                               <green>255</green>
                                               <blue>0</blue>
@@ -2935,6 +3225,15 @@ p, li { white-space: pre-wrap; }
                                               <red>190</red>
                                               <green>190</green>
                                               <blue>190</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>0</red>
+                                              <green>255</green>
+                                              <blue>0</blue>
                                              </color>
                                             </brush>
                                            </colorrole>
@@ -2996,11 +3295,29 @@ p, li { white-space: pre-wrap; }
                                              </color>
                                             </brush>
                                            </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>15</green>
+                                              <blue>29</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
                                           </active>
                                           <inactive>
                                            <colorrole role="Text">
                                             <brush brushstyle="SolidPattern">
                                              <color alpha="255">
+                                              <red>255</red>
+                                              <green>15</green>
+                                              <blue>29</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
                                               <red>255</red>
                                               <green>15</green>
                                               <blue>29</blue>
@@ -3015,6 +3332,15 @@ p, li { white-space: pre-wrap; }
                                               <red>190</red>
                                               <green>190</green>
                                               <blue>190</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>15</green>
+                                              <blue>29</blue>
                                              </color>
                                             </brush>
                                            </colorrole>
@@ -3058,11 +3384,29 @@ p, li { white-space: pre-wrap; }
                                              </color>
                                             </brush>
                                            </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>15</green>
+                                              <blue>29</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
                                           </active>
                                           <inactive>
                                            <colorrole role="Text">
                                             <brush brushstyle="SolidPattern">
                                              <color alpha="255">
+                                              <red>255</red>
+                                              <green>15</green>
+                                              <blue>29</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
                                               <red>255</red>
                                               <green>15</green>
                                               <blue>29</blue>
@@ -3077,6 +3421,15 @@ p, li { white-space: pre-wrap; }
                                               <red>190</red>
                                               <green>190</green>
                                               <blue>190</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>15</green>
+                                              <blue>29</blue>
                                              </color>
                                             </brush>
                                            </colorrole>
@@ -3138,11 +3491,29 @@ p, li { white-space: pre-wrap; }
                                              </color>
                                             </brush>
                                            </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>120</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
                                           </active>
                                           <inactive>
                                            <colorrole role="Text">
                                             <brush brushstyle="SolidPattern">
                                              <color alpha="255">
+                                              <red>255</red>
+                                              <green>120</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
                                               <red>255</red>
                                               <green>120</green>
                                               <blue>0</blue>
@@ -3157,6 +3528,15 @@ p, li { white-space: pre-wrap; }
                                               <red>190</red>
                                               <green>190</green>
                                               <blue>190</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>120</green>
+                                              <blue>0</blue>
                                              </color>
                                             </brush>
                                            </colorrole>
@@ -3200,11 +3580,29 @@ p, li { white-space: pre-wrap; }
                                              </color>
                                             </brush>
                                            </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>120</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
                                           </active>
                                           <inactive>
                                            <colorrole role="Text">
                                             <brush brushstyle="SolidPattern">
                                              <color alpha="255">
+                                              <red>255</red>
+                                              <green>120</green>
+                                              <blue>0</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
                                               <red>255</red>
                                               <green>120</green>
                                               <blue>0</blue>
@@ -3219,6 +3617,15 @@ p, li { white-space: pre-wrap; }
                                               <red>190</red>
                                               <green>190</green>
                                               <blue>190</blue>
+                                             </color>
+                                            </brush>
+                                           </colorrole>
+                                           <colorrole role="PlaceholderText">
+                                            <brush brushstyle="NoBrush">
+                                             <color alpha="128">
+                                              <red>255</red>
+                                              <green>120</green>
+                                              <blue>0</blue>
                                              </color>
                                             </brush>
                                            </colorrole>
@@ -3417,11 +3824,29 @@ p, li { white-space: pre-wrap; }
                                        </color>
                                       </brush>
                                      </colorrole>
+                                     <colorrole role="PlaceholderText">
+                                      <brush brushstyle="NoBrush">
+                                       <color alpha="128">
+                                        <red>0</red>
+                                        <green>0</green>
+                                        <blue>255</blue>
+                                       </color>
+                                      </brush>
+                                     </colorrole>
                                     </active>
                                     <inactive>
                                      <colorrole role="Text">
                                       <brush brushstyle="SolidPattern">
                                        <color alpha="255">
+                                        <red>0</red>
+                                        <green>0</green>
+                                        <blue>255</blue>
+                                       </color>
+                                      </brush>
+                                     </colorrole>
+                                     <colorrole role="PlaceholderText">
+                                      <brush brushstyle="NoBrush">
+                                       <color alpha="128">
                                         <red>0</red>
                                         <green>0</green>
                                         <blue>255</blue>
@@ -3436,6 +3861,15 @@ p, li { white-space: pre-wrap; }
                                         <red>118</red>
                                         <green>118</green>
                                         <blue>117</blue>
+                                       </color>
+                                      </brush>
+                                     </colorrole>
+                                     <colorrole role="PlaceholderText">
+                                      <brush brushstyle="NoBrush">
+                                       <color alpha="128">
+                                        <red>0</red>
+                                        <green>0</green>
+                                        <blue>255</blue>
                                        </color>
                                       </brush>
                                      </colorrole>
@@ -3490,11 +3924,29 @@ p, li { white-space: pre-wrap; }
                                        </color>
                                       </brush>
                                      </colorrole>
+                                     <colorrole role="PlaceholderText">
+                                      <brush brushstyle="NoBrush">
+                                       <color alpha="128">
+                                        <red>0</red>
+                                        <green>0</green>
+                                        <blue>255</blue>
+                                       </color>
+                                      </brush>
+                                     </colorrole>
                                     </active>
                                     <inactive>
                                      <colorrole role="Text">
                                       <brush brushstyle="SolidPattern">
                                        <color alpha="255">
+                                        <red>0</red>
+                                        <green>0</green>
+                                        <blue>255</blue>
+                                       </color>
+                                      </brush>
+                                     </colorrole>
+                                     <colorrole role="PlaceholderText">
+                                      <brush brushstyle="NoBrush">
+                                       <color alpha="128">
                                         <red>0</red>
                                         <green>0</green>
                                         <blue>255</blue>
@@ -3509,6 +3961,15 @@ p, li { white-space: pre-wrap; }
                                         <red>118</red>
                                         <green>118</green>
                                         <blue>117</blue>
+                                       </color>
+                                      </brush>
+                                     </colorrole>
+                                     <colorrole role="PlaceholderText">
+                                      <brush brushstyle="NoBrush">
+                                       <color alpha="128">
+                                        <red>0</red>
+                                        <green>0</green>
+                                        <blue>255</blue>
                                        </color>
                                       </brush>
                                      </colorrole>
@@ -3850,11 +4311,11 @@ p, li { white-space: pre-wrap; }
                   <attribute name="horizontalHeaderVisible">
                    <bool>true</bool>
                   </attribute>
-                  <attribute name="horizontalHeaderDefaultSectionSize">
-                   <number>50</number>
-                  </attribute>
                   <attribute name="horizontalHeaderMinimumSectionSize">
                    <number>25</number>
+                  </attribute>
+                  <attribute name="horizontalHeaderDefaultSectionSize">
+                   <number>50</number>
                   </attribute>
                   <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
                    <bool>false</bool>
@@ -4882,7 +5343,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>1560</width>
-     <height>28</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuHelp">
@@ -5208,6 +5669,12 @@ p, li { white-space: pre-wrap; }
    <extends>QTableWidget</extends>
    <header>RefRed/interfaces/mytablewidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>DeadTimeEntryPoint</class>
+   <extends>QGroupBox</extends>
+   <header>RefRed/interfaces/deadtime_entry.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources>
   <include location="../icons/icons.qrc"/>
@@ -5318,22 +5785,6 @@ p, li { white-space: pre-wrap; }
     <hint type="sourcelabel">
      <x>182</x>
      <y>915</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>778</x>
-     <y>586</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>qStep</sender>
-   <signal>textChanged(QString)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>widget_modified()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>238</x>
-     <y>661</y>
     </hint>
     <hint type="destinationlabel">
      <x>778</x>
@@ -5542,22 +5993,6 @@ p, li { white-space: pre-wrap; }
     <hint type="sourcelabel">
      <x>1299</x>
      <y>1348</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>778</x>
-     <y>586</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>eventTofBins</sender>
-   <signal>valueChanged(QString)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>widget_modified()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>238</x>
-     <y>586</y>
     </hint>
     <hint type="destinationlabel">
      <x>778</x>

--- a/RefRed/interfaces/sf_calculator_interface.ui
+++ b/RefRed/interfaces/sf_calculator_interface.ui
@@ -25,8 +25,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>1191</width>
-         <height>960</height>
+         <width>1187</width>
+         <height>914</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -178,11 +178,29 @@
                           </color>
                          </brush>
                         </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>170</red>
+                           <green>85</green>
+                           <blue>0</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
                        </active>
                        <inactive>
                         <colorrole role="Text">
                          <brush brushstyle="SolidPattern">
                           <color alpha="255">
+                           <red>170</red>
+                           <green>85</green>
+                           <blue>0</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
                            <red>170</red>
                            <green>85</green>
                            <blue>0</blue>
@@ -197,6 +215,15 @@
                            <red>118</red>
                            <green>118</green>
                            <blue>117</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>170</red>
+                           <green>85</green>
+                           <blue>0</blue>
                           </color>
                          </brush>
                         </colorrole>
@@ -265,11 +292,29 @@
                           </color>
                          </brush>
                         </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>0</red>
+                           <green>0</green>
+                           <blue>127</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
                        </active>
                        <inactive>
                         <colorrole role="Text">
                          <brush brushstyle="SolidPattern">
                           <color alpha="255">
+                           <red>0</red>
+                           <green>0</green>
+                           <blue>127</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
                            <red>0</red>
                            <green>0</green>
                            <blue>127</blue>
@@ -284,6 +329,15 @@
                            <red>118</red>
                            <green>118</green>
                            <blue>117</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>0</red>
+                           <green>0</green>
+                           <blue>127</blue>
                           </color>
                          </brush>
                         </colorrole>
@@ -352,11 +406,29 @@
                           </color>
                          </brush>
                         </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>0</red>
+                           <green>0</green>
+                           <blue>127</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
                        </active>
                        <inactive>
                         <colorrole role="Text">
                          <brush brushstyle="SolidPattern">
                           <color alpha="255">
+                           <red>0</red>
+                           <green>0</green>
+                           <blue>127</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
                            <red>0</red>
                            <green>0</green>
                            <blue>127</blue>
@@ -371,6 +443,15 @@
                            <red>118</red>
                            <green>118</green>
                            <blue>117</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>0</red>
+                           <green>0</green>
+                           <blue>127</blue>
                           </color>
                          </brush>
                         </colorrole>
@@ -439,11 +520,29 @@
                           </color>
                          </brush>
                         </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>170</red>
+                           <green>85</green>
+                           <blue>0</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
                        </active>
                        <inactive>
                         <colorrole role="Text">
                          <brush brushstyle="SolidPattern">
                           <color alpha="255">
+                           <red>170</red>
+                           <green>85</green>
+                           <blue>0</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
                            <red>170</red>
                            <green>85</green>
                            <blue>0</blue>
@@ -458,6 +557,15 @@
                            <red>118</red>
                            <green>118</green>
                            <blue>117</blue>
+                          </color>
+                         </brush>
+                        </colorrole>
+                        <colorrole role="PlaceholderText">
+                         <brush brushstyle="NoBrush">
+                          <color alpha="128">
+                           <red>170</red>
+                           <green>85</green>
+                           <blue>0</blue>
                           </color>
                          </brush>
                         </colorrole>
@@ -780,13 +888,15 @@
              </spacer>
             </item>
             <item>
-             <widget class="QPushButton" name="dead_time_button">
-              <property name="text">
-               <string>Dead time</string>
+             <widget class="DeadTimeEntryPoint" name="deadtime_entry">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
-              <property name="icon">
-               <iconset resource="../icons/icons.qrc">
-                <normaloff>:/General/cogwheel.png</normaloff>:/General/cogwheel.png</iconset>
+              <property name="title">
+               <string>Dead Time Correction</string>
               </property>
              </widget>
             </item>
@@ -1029,7 +1139,7 @@
      <x>0</x>
      <y>0</y>
      <width>1221</width>
-     <height>28</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -1105,6 +1215,12 @@
    <class>MPLWidgetNoLog</class>
    <extends>QWidget</extends>
    <header>RefRed/interfaces/mplwidgets.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>DeadTimeEntryPoint</class>
+   <extends>QGroupBox</extends>
+   <header>RefRed/interfaces/deadtime_entry.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -1461,22 +1577,6 @@
     <hint type="destinationlabel">
      <x>827</x>
      <y>610</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>dead_time_button</sender>
-   <signal>clicked()</signal>
-   <receiver>SFCalculatorInterface</receiver>
-   <slot>show_dead_time_dialog()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1010</x>
-     <y>457</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>610</x>
-     <y>387</y>
     </hint>
    </hints>
   </connection>

--- a/RefRed/main.py
+++ b/RefRed/main.py
@@ -25,6 +25,7 @@ from RefRed.gui_handling.observer import SpinBoxObserver
 from RefRed.initialization.gui import Gui as InitializeGui
 from RefRed.initialization.gui_connections import GuiConnections as MakeGuiConnections
 from RefRed.interfaces import load_ui
+from RefRed.interfaces.deadtime_settings import DeadTimeSettingsView
 from RefRed.load_reduced_data_set.load_reduced_data_set_handler import LoadReducedDataSetHandler
 from RefRed.load_reduced_data_set.reduced_ascii_data_right_click import ReducedAsciiDataRightClick
 from RefRed.metadata.metadata_finder import MetadataFinder
@@ -146,6 +147,11 @@ class MainGui(QtWidgets.QMainWindow):
         backgrounds_settings["data"].signal_second_background.connect(self.data_back_checkbox)
         backgrounds_settings["norm"].signal_first_background.connect(self.norm_back_checkbox)
         backgrounds_settings["norm"].signal_second_background.connect(self.norm_back_checkbox)
+
+        # deadtime_entry connections
+        self.deadtime_options = {"apply_deadtime": True, "paralyzable": True, "dead_time": 4.2, "tof_step": 150}
+        self.ui.deadtime_entry.applyCheckBox.stateChanged.connect(self.apply_deadtime_update)
+        self.ui.deadtime_entry.settingsButton.clicked.connect(self.show_deadtime_settings)
 
     # home button of plots
     def home_clicked_yi_plot(self):
@@ -651,6 +657,23 @@ class MainGui(QtWidgets.QMainWindow):
     def settings_editor(self):
         o_settings_editor = SettingsEditor(parent=self)
         o_settings_editor.show()
+
+    def apply_deadtime_update(self):
+        r"""Update option apply_deadtime of attribute deadtime_options when the associated checkbox
+        changes its state"""
+        apply_deadtime = self.ui.deadtime_entry.applyCheckBox.isChecked()
+        if self.deadtime_options["apply_deadtime"] != apply_deadtime:
+            self.deadtime_options["apply_deadtime"] = apply_deadtime
+
+    def show_deadtime_settings(self):
+        r"""Show the dialog for dead-time options. Update attribue deadtime options upon closing the dialog."""
+        dt_settings = DeadTimeSettingsView(parent=self)
+        dt_settings.set_state(
+            self.deadtime_options["paralyzable"], self.deadtime_options["dead_time"], self.deadtime_options["tof_step"]
+        )
+        dt_settings.exec_()
+        for option in ["paralyzable", "dead_time", "tof_step"]:
+            self.deadtime_options[option] = dt_settings.options[option]
 
     def closeEvent(self, event=None):
         SaveUserConfiguration(parent=self)

--- a/RefRed/reduction/global_reduction_settings_handler.py
+++ b/RefRed/reduction/global_reduction_settings_handler.py
@@ -24,7 +24,7 @@ class GlobalReductionSettingsHandler(object):
         self.angle_offset_error = self.get_angle_offset_error()
         self.tof_steps = self.get_tof_steps()
         self.apply_normalization = self.parent.ui.useNormalizationFlag.isChecked()
-        self.dead_time = self.parent.ui.deadtime_checkbox.isChecked()
+        self.dead_time = self.parent.ui.deadtime_entry.applyCheckBox.isChecked()
 
     def to_dict(self):
         """

--- a/RefRed/sf_calculator/reduction_sf_calculator.py
+++ b/RefRed/sf_calculator/reduction_sf_calculator.py
@@ -223,7 +223,6 @@ class ReductionSfCalculator(object):
             r")",
         ]
         script += "\n".join(mantid_call) + "\n"
-
         return script
 
     def refreshOutputFileContainPreview(self, output_file_name):

--- a/RefRed/sf_calculator/reduction_sf_calculator.py
+++ b/RefRed/sf_calculator/reduction_sf_calculator.py
@@ -223,6 +223,7 @@ class ReductionSfCalculator(object):
             r")",
         ]
         script += "\n".join(mantid_call) + "\n"
+
         return script
 
     def refreshOutputFileContainPreview(self, output_file_name):

--- a/test/test_fixtures.py
+++ b/test/test_fixtures.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 def test_data_server(data_server):
     assert Path(data_server.path_to('easy_data_set.csv')).exists()
+    with pytest.raises(FileNotFoundError):
+        Path(data_server.path_to('impossibe_to_find.dat')).exists()
 
 
 if __name__ == '__main__':

--- a/test/unit/RefRed/interfaces/test_deadtime_entry.py
+++ b/test/unit/RefRed/interfaces/test_deadtime_entry.py
@@ -1,6 +1,6 @@
 # third party imports
 import pytest
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt  # type: ignore
 
 # RefRed imports
 from RefRed.interfaces.deadtime_entry import DeadTimeEntryPoint  # Make sure to import your class correctly

--- a/test/unit/RefRed/interfaces/test_deadtime_entry.py
+++ b/test/unit/RefRed/interfaces/test_deadtime_entry.py
@@ -1,0 +1,42 @@
+# third party imports
+import pytest
+from qtpy.QtCore import Qt
+
+# RefRed imports
+from RefRed.interfaces.deadtime_entry import DeadTimeEntryPoint  # Make sure to import your class correctly
+
+
+@pytest.fixture
+def dead_time_entry_point(qtbot):
+    widget = DeadTimeEntryPoint()
+    qtbot.addWidget(widget)
+    return widget
+
+
+def test_initial_state(dead_time_entry_point):
+    assert not dead_time_entry_point.applyCheckBox.isChecked()
+    assert not dead_time_entry_point.settingsButton.isEnabled()
+
+
+def test_checkbox_interaction(dead_time_entry_point, qtbot):
+    # Simulate checking the checkbox
+    qtbot.mouseClick(dead_time_entry_point.applyCheckBox, Qt.LeftButton)
+    # Test if the checkbox is checked
+    assert dead_time_entry_point.applyCheckBox.isChecked()
+    # Test if the settings button is now enabled
+    assert dead_time_entry_point.settingsButton.isEnabled()
+
+
+def test_uncheck_checkbox(dead_time_entry_point, qtbot):
+    # First, check the checkbox
+    qtbot.mouseClick(dead_time_entry_point.applyCheckBox, Qt.LeftButton)
+    # Now, uncheck it
+    qtbot.mouseClick(dead_time_entry_point.applyCheckBox, Qt.LeftButton)
+    # Test if the checkbox is unchecked
+    assert not dead_time_entry_point.applyCheckBox.isChecked()
+    # Test if the settings button is now disabled
+    assert not dead_time_entry_point.settingsButton.isEnabled()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/test/unit/RefRed/sf_calculator/test_sf_calculator.py
+++ b/test/unit/RefRed/sf_calculator/test_sf_calculator.py
@@ -61,7 +61,6 @@ class TestSFCalculator:
         new_paralyzable = False
         new_dead_time = 5.0
         new_tof_step = 200
-        calculator = self.app
 
         class MockDeadTimeSettingsView:
             def __init__(self, parent=None):
@@ -75,10 +74,10 @@ class TestSFCalculator:
                 pass
 
         monkeypatch.setattr("RefRed.sf_calculator.sf_calculator.DeadTimeSettingsView", MockDeadTimeSettingsView)
-        calculator.show_dead_time_dialog()
-        assert calculator.paralyzable_deadtime == new_paralyzable
-        assert calculator.deadtime_value == new_dead_time
-        assert calculator.deadtime_tof_step == new_tof_step
+        self.app.show_dead_time_dialog()
+        assert self.app.paralyzable_deadtime == new_paralyzable
+        assert self.app.deadtime_value == new_dead_time
+        assert self.app.deadtime_tof_step == new_tof_step
 
 
 if __name__ == '__main__':

--- a/test/unit/RefRed/sf_calculator/test_sf_calculator.py
+++ b/test/unit/RefRed/sf_calculator/test_sf_calculator.py
@@ -1,12 +1,34 @@
+# third party imports
 import pytest
+from qtpy.QtCore import Qt
+
+# RefRed imports
+from RefRed.sf_calculator.sf_calculator import SFCalculator
 
 
-def test_sf_calculator():
-    """Test class SFCalculator
+class TestSFCalculator:
+    @pytest.fixture(autouse=True)
+    def setup_class(self, qtbot):
+        self.app = SFCalculator()
+        qtbot.addWidget(self.app)
 
-    Note: this is a pytest-pyqt test
-    """
-    return
+    def test_apply_deadtime_update_checked(self, qtbot):
+        """Test the apply_deadtime_update function when the checkbox is checked."""
+        # Ensure checkbox starts unchecked
+        self.app.ui.deadtime_entry.applyCheckBox.setChecked(False)
+        # Simulate checking the checkbox
+        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, Qt.LeftButton)
+        # Assert that the apply_deadtime attribute is now True
+        assert self.app.apply_deadtime is True
+
+    def test_apply_deadtime_update_unchecked(self, qtbot):
+        """Test the apply_deadtime_update function when the checkbox is unchecked."""
+        # Ensure checkbox starts checked
+        self.app.ui.deadtime_entry.applyCheckBox.setChecked(True)
+        # Simulate unchecking the checkbox
+        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, Qt.LeftButton)
+        # Assert that the apply_deadtime attribute is now False
+        assert self.app.apply_deadtime is False
 
 
 if __name__ == '__main__':

--- a/test/unit/RefRed/sf_calculator/test_sf_calculator.py
+++ b/test/unit/RefRed/sf_calculator/test_sf_calculator.py
@@ -1,7 +1,6 @@
 # third party imports
 import pytest
-from qtpy import QtWidgets
-from qtpy.QtCore import Qt
+from qtpy import QtCore, QtWidgets
 
 # RefRed imports
 from RefRed.sf_calculator.sf_calculator import SFCalculator
@@ -18,7 +17,7 @@ class TestSFCalculator:
         # Ensure checkbox starts unchecked
         self.app.ui.deadtime_entry.applyCheckBox.setChecked(False)
         # Simulate checking the checkbox
-        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, Qt.LeftButton)
+        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, QtCore.Qt.LeftButton)
         # Assert that the apply_deadtime attribute is now True
         assert self.app.apply_deadtime is True
 
@@ -27,7 +26,7 @@ class TestSFCalculator:
         # Ensure checkbox starts checked
         self.app.ui.deadtime_entry.applyCheckBox.setChecked(True)
         # Simulate unchecking the checkbox
-        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, Qt.LeftButton)
+        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, QtCore.Qt.LeftButton)
         # Assert that the apply_deadtime attribute is now False
         assert self.app.apply_deadtime is False
 

--- a/test/unit/RefRed/sf_calculator/test_sf_calculator.py
+++ b/test/unit/RefRed/sf_calculator/test_sf_calculator.py
@@ -1,6 +1,6 @@
 # third party imports
 import pytest
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets  # type: ignore
 
 # RefRed imports
 from RefRed.sf_calculator.sf_calculator import SFCalculator

--- a/test/unit/RefRed/sf_calculator/test_sf_calculator.py
+++ b/test/unit/RefRed/sf_calculator/test_sf_calculator.py
@@ -1,5 +1,6 @@
 # third party imports
 import pytest
+from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
 # RefRed imports
@@ -29,6 +30,56 @@ class TestSFCalculator:
         qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, Qt.LeftButton)
         # Assert that the apply_deadtime attribute is now False
         assert self.app.apply_deadtime is False
+
+    def test_show_dead_time_dialog_default_values(self, monkeypatch):
+        calculator = self.app  # endow closure environment to MockDeadTimeSettingsView
+
+        class MockDeadTimeSettingsView:
+            def __init__(self, parent=None):
+                r"""Mocking the DeadTimeSettingsView to return default values without user interaction"""
+                self.options = {
+                    'paralyzable': calculator.paralyzable_deadtime,
+                    'dead_time': calculator.deadtime_value,
+                    'tof_step': calculator.deadtime_tof_step,
+                }
+
+            def exec_(self):
+                return QtWidgets.QDialog.Accepted
+
+            def set_state(self, paralyzable, dead_time, tof_step):
+                self.options['paralyzable'] = paralyzable
+                self.options['dead_time'] = dead_time
+                self.options['tof_step'] = tof_step
+
+        monkeypatch.setattr("RefRed.sf_calculator.sf_calculator.DeadTimeSettingsView", MockDeadTimeSettingsView)
+        self.app.show_dead_time_dialog()
+        assert self.app.paralyzable_deadtime is True
+        assert self.app.deadtime_value == 4.2
+        assert self.app.deadtime_tof_step == 150
+
+    def test_show_dead_time_dialog_updated_values(self, monkeypatch):
+        # endow closure environment to MockDeadTimeSettingsView
+        new_paralyzable = False
+        new_dead_time = 5.0
+        new_tof_step = 200
+        calculator = self.app
+
+        class MockDeadTimeSettingsView:
+            def __init__(self, parent=None):
+                r"""Mocking the DeadTimeSettingsView to return values without user interaction"""
+                self.options = {'paralyzable': new_paralyzable, 'dead_time': new_dead_time, 'tof_step': new_tof_step}
+
+            def exec_(self):
+                return QtWidgets.QDialog.Accepted
+
+            def set_state(self, paralyzable, dead_time, tof_step):
+                pass
+
+        monkeypatch.setattr("RefRed.sf_calculator.sf_calculator.DeadTimeSettingsView", MockDeadTimeSettingsView)
+        calculator.show_dead_time_dialog()
+        assert calculator.paralyzable_deadtime == new_paralyzable
+        assert calculator.deadtime_value == new_dead_time
+        assert calculator.deadtime_tof_step == new_tof_step
 
 
 if __name__ == '__main__':

--- a/test/unit/RefRed/test_main.py
+++ b/test/unit/RefRed/test_main.py
@@ -1,21 +1,25 @@
-# third-party imports
+# standard imports
 import unittest.mock as mock
+
+# third-party imports
 import pytest
+from qtpy import QtCore, QtWidgets  # type: ignore
 
 # RefRed imports
 from RefRed.main import MainGui
 
 
 class TestMainGui:
-    def test_init(self, qtbot):
-        window_main = MainGui()
-        qtbot.addWidget(window_main)
-        assert "Liquids Reflectometer Reduction" in window_main.windowTitle()
+    @pytest.fixture(autouse=True)
+    def setup_class(self, qtbot):
+        self.app = MainGui()
+        qtbot.addWidget(self.app)
 
-    def test_run_reduction_button(self, qtbot):
-        window_main = MainGui()
-        qtbot.addWidget(window_main)
-        assert window_main.run_reduction_button() is None
+    def test_init(self):
+        assert "Liquids Reflectometer Reduction" in self.app.windowTitle()
+
+    def test_run_reduction_button(self):
+        assert self.app.run_reduction_button() is None
 
     @mock.patch('RefRed.main.MainGui.file_loaded_signal')
     @mock.patch('RefRed.main.InitializeGui')
@@ -41,6 +45,77 @@ class TestMainGui:
         mainGui = MainGui(parent=parent)
         mainGui.load_configuration()
         mockLoadConfiguration.assert_called()
+
+    def test_apply_deadtime_update_checked(self, qtbot):
+        """Test the apply_deadtime_update function when the checkbox is checked."""
+        # Ensure checkbox starts unchecked
+        self.app.ui.deadtime_entry.applyCheckBox.setChecked(False)
+        # Simulate checking the checkbox
+        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, QtCore.Qt.LeftButton)
+        # Assert that the apply_deadtime attribute is now True
+        assert self.app.deadtime_options["apply_deadtime"] is True
+
+    def test_apply_deadtime_update_unchecked(self, qtbot):
+        """Test the apply_deadtime_update function when the checkbox is unchecked."""
+        # Ensure checkbox starts checked
+        self.app.ui.deadtime_entry.applyCheckBox.setChecked(True)
+        # Simulate unchecking the checkbox
+        qtbot.mouseClick(self.app.ui.deadtime_entry.applyCheckBox, QtCore.Qt.LeftButton)
+        # Assert that the apply_deadtime attribute is now False
+        assert self.app.deadtime_options["apply_deadtime"] is False
+
+    def test_show_deadtime_settings_default_values(self, monkeypatch):
+        main_gui = self.app  # endow closure environment to MockDeadTimeSettingsView
+
+        class MockDeadTimeSettingsView:
+            def __init__(self, parent=None):
+                r"""Mocking the DeadTimeSettingsView to return default values without user interaction"""
+                self.options = {
+                    'paralyzable': main_gui.deadtime_options["paralyzable"],
+                    'dead_time': main_gui.deadtime_options["dead_time"],
+                    'tof_step': main_gui.deadtime_options["tof_step"],
+                }
+
+            def exec_(self):
+                return QtWidgets.QDialog.Accepted
+
+            def set_state(self, paralyzable, dead_time, tof_step):
+                self.options['paralyzable'] = paralyzable
+                self.options['dead_time'] = dead_time
+                self.options['tof_step'] = tof_step
+
+        monkeypatch.setattr("RefRed.main.DeadTimeSettingsView", MockDeadTimeSettingsView)
+        self.app.show_deadtime_settings()
+        assert self.app.deadtime_options["paralyzable"] is True
+        assert self.app.deadtime_options["dead_time"] == 4.2
+        assert self.app.deadtime_options["tof_step"] == 150
+
+    def test_show_deadtime_settings_updated_values(self, monkeypatch):
+        # endow closure environment to MockDeadTimeSettingsView
+        new_paralyzable = False
+        new_dead_time = 5.0
+        new_tof_step = 200
+
+        class MockDeadTimeSettingsView:
+            def __init__(self, parent=None):
+                r"""Mocking the DeadTimeSettingsView to return default values without user interaction"""
+                self.options = {
+                    'paralyzable': new_paralyzable,
+                    'dead_time': new_dead_time,
+                    'tof_step': new_tof_step,
+                }
+
+            def exec_(self):
+                return QtWidgets.QDialog.Accepted
+
+            def set_state(self, paralyzable, dead_time, tof_step):
+                pass
+
+        monkeypatch.setattr("RefRed.main.DeadTimeSettingsView", MockDeadTimeSettingsView)
+        self.app.show_deadtime_settings()
+        assert self.app.deadtime_options["paralyzable"] == new_paralyzable
+        assert self.app.deadtime_options["dead_time"] == new_dead_time
+        assert self.app.deadtime_options["tof_step"] == new_tof_step
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
References [Task 4953 [REFRED] Common entry-widget for MainGui and SFCalculatorUI](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4953)

# Manual test for the reviewer
Before running the manual tests, install the conda environment and install the source in editable mode
```bash
> conda env create --solver libmamba --name refred-dev --file ./environment.yml
> conda activate refred-dev
(refred-dev)> pip install -e .
```
Start RefRed GUI
```bash
(refred-dev)> PYTHONPATH=$(pwd):$PYTHONPATH ./scripts/start_refred.py
```
Or run tests
```bash
(refred-dev)> pytest test/unit/RefRed/test_main.py
```

# Check list for the reviewer
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

