### PR TITLE
Update deadtime_settings.py

### DIFF
--- a/RefRed/interfaces/deadtime_settings.py
+++ b/RefRed/interfaces/deadtime_settings.py
@@ -58,7 +58,8 @@ class DeadTimeSettingsModel(GlobalSettings):
     def from_xml(self, node: Element):
         r"""Update the settings from the contents of an XML element
 
-        If the XMl element is missing one (or more) setting, the setting(s) are not updated.
+        If the XMl element is missing one (or more) setting, the setting(s) are not updated except for
+        field `apply_deadtime`, which is set to `False.
         XML tag names name are same as those produced by lr_reduction.reduction_template_reader.to_xml()
 
         Example
@@ -86,6 +87,9 @@ class DeadTimeSettingsModel(GlobalSettings):
             if len(tmp):
                 value = tmp[0].childNodes[0].nodeValue
                 setattr(self, field, converter(value))
+            elif field == "apply_deadtime":
+                # old XML files don't have dead time info, so we make sure it's not used.
+                setattr(self, "apply_deadtime", False)
         return self
 
     def as_template_reader_dict(self) -> Dict[str, Any]:

--- a/RefRed/interfaces/deadtime_settings.py
+++ b/RefRed/interfaces/deadtime_settings.py
@@ -13,7 +13,7 @@ class DeadTimeSettingsModel(GlobalSettings):
     r"""Stores all options for the dead time correction. These are global options"""
 
     # pydantic fields
-    apply_deadtime: bool = True
+    apply_deadtime: bool = False
     paralyzable: bool = True
     dead_time: float = 4.2
     tof_step: float = 150.0

--- a/test/unit/RefRed/interfaces/test_deadtime_settings.py
+++ b/test/unit/RefRed/interfaces/test_deadtime_settings.py
@@ -11,7 +11,7 @@ from RefRed.interfaces.deadtime_settings import DeadTimeSettingsModel
 class TestDeadTimeSettingsModel:
     def test_initialization_with_defaults(self):
         model = DeadTimeSettingsModel()
-        assert model.apply_deadtime is True
+        assert model.apply_deadtime is False
         assert model.paralyzable is True
         assert model.dead_time == 4.2
         assert model.tof_step == 150


### PR DESCRIPTION
We need to be consistent with old template.xml files. If they do not contain the dead time parameters, then the default should be not to apply it.

The proposed change will do that when refred is started and a template is loaded for the first time.

We should add a condition so that if the `dead_time_correction` is missing, then the option should be set to false in the UI regardless of what it was. At the moment the last used value of `apply_deadtime` is kept.