### PR TITLE
bump Mantid version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,11 @@
 name: refred
 channels:
-  - mantid/label/nightly
+  - mantid/label/main
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10
-  - mantid>6.9.20240318
+  - python=3.10.*
+  - mantid=6.10.0
   - qt==5.15.8
   - pyqt>=5.15,<6
   - qtpy>=1.9.0


### PR DESCRIPTION
# References
- [EWM #6010](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6010)
<!-- Links to related issues or pull requests -->

# Description of the changes:
simple update the version of the Mantid dependency to the latest Productio release

# Manual test for the reviewer
([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/dev-docs/testing.rst#running-manual-tests-in-a-pull-request))

Start RefRed GUI
```bash
(refred-dev)> PYTHONPATH=$(pwd):$PYTHONPATH ./scripts/start_refred.py
```
Or run tests
```bash
(refred-dev)> pytest test/unit/RefRed/test_main.py
```

# Check list for the reviewer
- [ ] I have verified the proposed changes
- [ ] Author included tests for the proposed changes
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
    + [ ] new functions and classes detailed docstrings, parameters documented
- [ ] All tests are passing
- [ ] Documentation is up to date

# Check list for the author
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly
- [ ] I included a link to IBM EWM Story or Defect
