### PR TITLE
Make sure full detector range is available to spinboxes

### DIFF
--- a/RefRed/interfaces/plot_dialog_refl_interface.ui
+++ b/RefRed/interfaces/plot_dialog_refl_interface.ui
@@ -124,7 +124,7 @@
                     </palette>
                    </property>
                    <property name="maximum">
-                    <number>255</number>
+                    <number>303</number>
                    </property>
                   </widget>
                  </item>
@@ -199,7 +199,7 @@
                     </palette>
                    </property>
                    <property name="maximum">
-                    <number>255</number>
+                    <number>303</number>
                    </property>
                    <property name="value">
                     <number>255</number>
@@ -292,7 +292,7 @@
                     </palette>
                    </property>
                    <property name="maximum">
-                    <number>255</number>
+                    <number>303</number>
                    </property>
                   </widget>
                  </item>
@@ -367,7 +367,7 @@
                     </palette>
                    </property>
                    <property name="maximum">
-                    <number>255</number>
+                    <number>303</number>
                    </property>
                    <property name="value">
                     <number>255</number>
@@ -463,7 +463,7 @@
                     </palette>
                    </property>
                    <property name="maximum">
-                    <number>255</number>
+                    <number>303</number>
                    </property>
                   </widget>
                  </item>
@@ -541,7 +541,7 @@
                     </palette>
                    </property>
                    <property name="maximum">
-                    <number>255</number>
+                    <number>303</number>
                    </property>
                    <property name="value">
                     <number>255</number>

--- a/RefRed/interfaces/refred_main_interface.ui
+++ b/RefRed/interfaces/refred_main_interface.ui
@@ -39,7 +39,7 @@
          <x>0</x>
          <y>0</y>
          <width>1540</width>
-         <height>1319</height>
+         <height>1321</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_68">
@@ -1864,7 +1864,7 @@ p, li { white-space: pre-wrap; }
                    <bool>true</bool>
                   </property>
                   <property name="currentIndex">
-                   <number>1</number>
+                   <number>0</number>
                   </property>
                   <widget class="QWidget" name="tab">
                    <property name="enabled">
@@ -2061,7 +2061,7 @@ p, li { white-space: pre-wrap; }
                                      </palette>
                                     </property>
                                     <property name="maximum">
-                                     <number>255</number>
+                                     <number>303</number>
                                     </property>
                                    </widget>
                                   </item>
@@ -2132,7 +2132,7 @@ p, li { white-space: pre-wrap; }
                                      </palette>
                                     </property>
                                     <property name="maximum">
-                                     <number>255</number>
+                                     <number>303</number>
                                     </property>
                                     <property name="value">
                                      <number>255</number>
@@ -2265,7 +2265,7 @@ p, li { white-space: pre-wrap; }
                                      </palette>
                                     </property>
                                     <property name="maximum">
-                                     <number>255</number>
+                                     <number>303</number>
                                     </property>
                                    </widget>
                                   </item>
@@ -2336,7 +2336,7 @@ p, li { white-space: pre-wrap; }
                                      </palette>
                                     </property>
                                     <property name="maximum">
-                                     <number>255</number>
+                                     <number>303</number>
                                     </property>
                                     <property name="value">
                                      <number>255</number>
@@ -2472,7 +2472,7 @@ p, li { white-space: pre-wrap; }
                                      </palette>
                                     </property>
                                     <property name="maximum">
-                                     <number>255</number>
+                                     <number>303</number>
                                     </property>
                                    </widget>
                                   </item>
@@ -2546,7 +2546,7 @@ p, li { white-space: pre-wrap; }
                                      </palette>
                                     </property>
                                     <property name="maximum">
-                                     <number>255</number>
+                                     <number>303</number>
                                     </property>
                                     <property name="value">
                                      <number>255</number>
@@ -3152,7 +3152,7 @@ p, li { white-space: pre-wrap; }
                                          </palette>
                                         </property>
                                         <property name="maximum">
-                                         <number>255</number>
+                                         <number>303</number>
                                         </property>
                                        </widget>
                                       </item>
@@ -3241,7 +3241,7 @@ p, li { white-space: pre-wrap; }
                                          </palette>
                                         </property>
                                         <property name="maximum">
-                                         <number>255</number>
+                                         <number>303</number>
                                         </property>
                                         <property name="value">
                                          <number>255</number>
@@ -3348,7 +3348,7 @@ p, li { white-space: pre-wrap; }
                                          </palette>
                                         </property>
                                         <property name="maximum">
-                                         <number>255</number>
+                                         <number>303</number>
                                         </property>
                                        </widget>
                                       </item>
@@ -3437,7 +3437,7 @@ p, li { white-space: pre-wrap; }
                                          </palette>
                                         </property>
                                         <property name="maximum">
-                                         <number>255</number>
+                                         <number>303</number>
                                         </property>
                                         <property name="value">
                                          <number>255</number>
@@ -3544,7 +3544,7 @@ p, li { white-space: pre-wrap; }
                                          </palette>
                                         </property>
                                         <property name="maximum">
-                                         <number>255</number>
+                                         <number>303</number>
                                         </property>
                                        </widget>
                                       </item>
@@ -3633,7 +3633,7 @@ p, li { white-space: pre-wrap; }
                                          </palette>
                                         </property>
                                         <property name="maximum">
-                                         <number>255</number>
+                                         <number>303</number>
                                         </property>
                                         <property name="value">
                                          <number>255</number>
@@ -5343,7 +5343,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>1560</width>
-     <height>22</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuHelp">

--- a/RefRed/plot/popup_plot_1d.py
+++ b/RefRed/plot/popup_plot_1d.py
@@ -146,12 +146,12 @@ class PopupPlot1d(QDialog):
             self.ui.plotBack2ToSpinBox.setValue(back1)
 
     def reset_max_ui_value(self):
-        self.ui.plotPeakFromSpinBox.setMaximum(255)
-        self.ui.plotPeakToSpinBox.setMaximum(255)
-        self.ui.plotBackFromSpinBox.setMaximum(255)
-        self.ui.plotBackToSpinBox.setMaximum(255)
-        self.ui.plotBack2FromSpinBox.setMaximum(255)
-        self.ui.plotBack2ToSpinBox.setMaximum(255)
+        self.ui.plotPeakFromSpinBox.setMaximum(self.nbr_pixel_y_axis)
+        self.ui.plotPeakToSpinBox.setMaximum(self.nbr_pixel_y_axis)
+        self.ui.plotBackFromSpinBox.setMaximum(self.nbr_pixel_y_axis)
+        self.ui.plotBackToSpinBox.setMaximum(self.nbr_pixel_y_axis)
+        self.ui.plotBack2FromSpinBox.setMaximum(self.nbr_pixel_y_axis)
+        self.ui.plotBack2ToSpinBox.setMaximum(self.nbr_pixel_y_axis)
 
     def get_ycountsdata_of_tof_range_selected(self):
         if self.data.tof_range_auto_flag:


### PR DESCRIPTION
The spin boxes used to select peaks and background went to pixel 255 (for 256 pixels), but it should go to 303 (for 304 pixels).