### PR TITLE
Fix emission delay correction

### DIFF
--- a/RefRed/calculations/lr_data.py
+++ b/RefRed/calculations/lr_data.py
@@ -146,10 +146,8 @@ class LRData(object):
         if use_emission_delay:
             wl_min = self.lambda_requested - wl_half_width
             wl_max = self.lambda_requested + wl_half_width
-            # Empirical additional delay to get rid of the ramp
-            ramp_delay = -450 + 100.0 * (self.lambda_requested - 4)
-            tmin += t_off + t_mult * wl_min + ramp_delay
-            tmax += t_off + t_mult * wl_max
+            tmin -= t_off + t_mult * wl_min
+            tmax -= t_off + t_mult * wl_max
 
         if lconfig is not None:
             autotmin = float(lconfig.tof_range[0])

--- a/RefRed/sf_calculator/lr_data.py
+++ b/RefRed/sf_calculator/lr_data.py
@@ -94,9 +94,7 @@ class LRData(object):
         if use_emission_delay:
             wl_min = self.lambda_requested - wl_half_width
             wl_max = self.lambda_requested + wl_half_width
-            # Empirical additional delay to get rid of the ramp
-            ramp_delay = -450 + 100.0 * (self.lambda_requested - 4)
-            tmin += t_off + t_mult * wl_min + ramp_delay
+            tmin += t_off + t_mult * wl_min
             tmax += t_off + t_mult * wl_max
 
         if self.read_options['is_auto_tof_finder'] or self.tof_range is None:

--- a/RefRed/sf_calculator/lr_data.py
+++ b/RefRed/sf_calculator/lr_data.py
@@ -94,8 +94,8 @@ class LRData(object):
         if use_emission_delay:
             wl_min = self.lambda_requested - wl_half_width
             wl_max = self.lambda_requested + wl_half_width
-            tmin += t_off + t_mult * wl_min
-            tmax += t_off + t_mult * wl_max
+            tmin -= t_off + t_mult * wl_min
+            tmax -= t_off + t_mult * wl_max
 
         if self.read_options['is_auto_tof_finder'] or self.tof_range is None:
             autotmin = tmin


### PR DESCRIPTION
I made a sign error when adding the emission delay correction. The measured TOF is longer because of the delay, so we have to subtract the emission time.