### PR TITLE
Force angle offset to zero

### DIFF
--- a/RefRed/configuration/export_xml_config.py
+++ b/RefRed/configuration/export_xml_config.py
@@ -145,10 +145,8 @@ class ExportXMLConfig(object):
             str_array.append('   <auto_q_binning>False</auto_q_binning>\n')
 
             # The angle offset is currently not exposed in the UI, so we set it to 0.
-            angleValue = 0
-            angleError = 0
-            str_array.append('   <angle_offset>' + angleValue + '</angle_offset>\n')
-            str_array.append('   <angle_offset_error>' + angleError + '</angle_offset_error>\n')
+            str_array.append('   <angle_offset> 0 </angle_offset>\n')
+            str_array.append('   <angle_offset_error> 0 </angle_offset_error>\n')
 
             q_step = str(self.parent.ui.qStep.text())
             str_array.append('   <q_step>' + q_step + '</q_step>\n')

--- a/RefRed/configuration/export_xml_config.py
+++ b/RefRed/configuration/export_xml_config.py
@@ -144,8 +144,9 @@ class ExportXMLConfig(object):
 
             str_array.append('   <auto_q_binning>False</auto_q_binning>\n')
 
-            angleValue = str(self.parent.ui.angleOffsetValue.text())
-            angleError = str(self.parent.ui.angleOffsetError.text())
+            # The angle offset is currently not exposed in the UI, so we set it to 0.
+            angleValue = 0
+            angleError = 0
             str_array.append('   <angle_offset>' + angleValue + '</angle_offset>\n')
             str_array.append('   <angle_offset_error>' + angleError + '</angle_offset_error>\n')
 

--- a/RefRed/reduction/global_reduction_settings_handler.py
+++ b/RefRed/reduction/global_reduction_settings_handler.py
@@ -32,8 +32,8 @@ class GlobalReductionSettingsHandler(object):
                 "scaling_factor_flag": self.parent.ui.scalingFactorFlag.isChecked(),
                 "scaling_factor_file": str(self.parent.full_scaling_factor_file_name),
                 "slits_width_flag": True,
-                "angle_offset": float(self.parent.ui.angleOffsetValue.text()),
-                "angle_offset_error": float(self.parent.ui.angleOffsetError.text()),
+                "angle_offset": 0,
+                "angle_offset_error": 0,
                 "tof_steps": float(self.parent.ui.eventTofBins.text()),
                 "apply_normalization": self.parent.ui.useNormalizationFlag.isChecked(),
                 "dead_time": self.parent.deadtime_settings,  # an instance of `DeadTimeSettingsModel`


### PR DESCRIPTION
The angle offset is not exposed in the UI. Although it could be brought back, it was decided a while back to hide it. The problem is that it's value is still passed to the reduction, so an old template with an offset would carry over to the reduction.

To avoid this, we set the offset to zero in the template and reduction settings.