### PR TITLE
update mantid to 6.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Workflow files stored in the default location of `.github/workflows`
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -16,8 +16,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
         name: Setup Conda
         with:
           auto-update-conda: true
@@ -48,7 +48,7 @@ jobs:
 
       - name: Trigger deploy
         id: trigger
-        uses: eic/trigger-gitlab-ci@v2
+        uses: eic/trigger-gitlab-ci@v3
         with:
           url: https://code.ornl.gov
           token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
             CONDA_ENV="${{ steps.conda_env_name.outputs.name }}"
 
       - name: Annotate commit
-        uses: peter-evans/commit-comment@v2
+        uses: peter-evans/commit-comment@v3
         with:
           body: |
             GitLab pipeline for ${{ steps.conda_env_name.outputs.name }} has been submitted for this commit: ${{ steps.trigger.outputs.web_url }}

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,6 +16,18 @@ Release Notes
 - MR #XYZ: one-liner description
 
 
+5.2.1
+-----
+YYYY-MM-DD
+
+**Of interest to the User**:
+
+- MR #XYZ: one-liner description
+
+**Of interest to the Developer:**
+
+-  PR #150 Update mantid to 6.12.0
+
 5.2.0
 -----
 2025-03-18

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python=3.10.*
-  - mantid=6.10.0
+  - mantid=6.12.0
   - qt==5.15.8
   - pyqt>=5.15,<6
   - qtpy>=1.9.0
@@ -14,15 +14,14 @@ dependencies:
   - pydantic
   - pip
   - pip:
-    - git+https://github.com/neutrons/LiquidsReflectometer.git@v2.1.12#egg=lr_reduction
-# documentation
+      - git+https://github.com/neutrons/LiquidsReflectometer.git@v2.1.13#egg=lr_reduction
+  # documentation
   - sphinx
   - sphinx_rtd_theme
-# development
+  # development
   - ruff
   - mypy
   - pre-commit
   - pytest
   - pytest-cov
   - pytest-qt
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ scipy
 PyQt5
 qtpy
 setuptools
-lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.1.12#egg=lr_reduction
+lr_reduction@git+https://github.com/neutrons/LiquidsReflectometer.git@v2.1.13#egg=lr_reduction


### PR DESCRIPTION
## Description of work:

Additionally had to update github actions for CI to pass. 
Added dependabot to inform us of action updates automatically

Check all that apply:
- [x] added [release notes](https://github.com/neutrons/RefRed/blob/next/docs/release_notes.rst) (if not, provide an explanation in the work description)
- [ ] ~~updated documentation~~
- [ ] ~~Source added/refactored~~
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~
- [x] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Story 10179](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10179)
- Links to related issues or pull requests: https://github.com/neutrons/LiquidsReflectometer/pull/65


# Manual test for the reviewer
([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

Start RefRed GUI
```bash
(refred)> PYTHONPATH=$(pwd):$PYTHONPATH ./scripts/start_refred.py
```
Or run tests
```bash
(refred)> pytest test/unit/RefRed/test_main.py
```

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/RefRed/blob/next/docs/release_notes.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
