### PR TITLE
Fix for ROI ranges out of sync

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,19 +17,6 @@ Check all that apply:
 
 ([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))
 
-Start RefRed GUI
-
-```bash
-(refred)
-$ PYTHONPATH=$(pwd):$PYTHONPATH ./scripts/start_refred.py
-```
-
-Or run tests
-
-```bash
-$ pixi run test
-```
-
 # Check list for the reviewer
 
 - [ ] best software practices

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -36,6 +39,9 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -76,6 +82,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [tests, build]
     if: startsWith(github.ref, 'refs/tags/v')
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/src/refred/autopopulatemaintable/reductiontable_auto_fill.py
+++ b/src/refred/autopopulatemaintable/reductiontable_auto_fill.py
@@ -285,10 +285,11 @@ class ReductionTableAutoFill(object):
         """
         data_table_cell = None
         for row_index in range(self.parent.REDUCTIONTABLE_MAX_ROWCOUNT):
+            _table_cell: LRData | None = None
             if self.data_type_selected == "data":
-                _table_cell: LRData = self.big_table_data.reflectometry_data(row_index)
+                _table_cell = self.big_table_data.reflectometry_data(row_index)
             else:
-                _table_cell: LRData = self.big_table_data.normalization_data(row_index)
+                _table_cell = self.big_table_data.normalization_data(row_index)
             if _table_cell is not None and _table_cell.run_number == run:
                 data_table_cell = _table_cell
                 break

--- a/src/refred/autopopulatemaintable/reductiontable_auto_fill.py
+++ b/src/refred/autopopulatemaintable/reductiontable_auto_fill.py
@@ -287,9 +287,9 @@ class ReductionTableAutoFill(object):
         for row_index in range(self.parent.REDUCTIONTABLE_MAX_ROWCOUNT):
             _table_cell: LRData | None = None
             if self.data_type_selected == "data":
-                _table_cell = self.big_table_data.reflectometry_data(row_index)
+                _table_cell = self.parent.big_table_data.reflectometry_data(row_index)
             else:
-                _table_cell = self.big_table_data.normalization_data(row_index)
+                _table_cell = self.parent.big_table_data.normalization_data(row_index)
             if _table_cell is not None and _table_cell.run_number == run:
                 data_table_cell = _table_cell
                 break

--- a/src/refred/calculations/check_list_run_compatibility_and_display.py
+++ b/src/refred/calculations/check_list_run_compatibility_and_display.py
@@ -104,11 +104,14 @@ class CheckListRunCompatibilityAndDisplay(object):
         self.parent.big_table_data = big_table_data
 
     def loading_lr_data(self):
+        """Creates an instance of LRData for the loaded workspace"""
         wks = self.wks
-        lrdata = LRData(wks, parent=self.parent)
-        self.lrdata = lrdata
         big_table_data = self.parent.big_table_data
         col_index = 0 if self.is_working_with_data_column else 1
+        reduction_table_cell = big_table_data[self.row, col_index]
+        # when loading a run in an existing cell, big_table_cell is not None and LRData will copy existing config
+        lrdata = LRData(wks, parent=self.parent, reduction_table_cell=reduction_table_cell)
+        self.lrdata = lrdata
         big_table_data[self.row, col_index] = lrdata
         self.parent.big_table_data = big_table_data
 

--- a/src/refred/plot/display_plots.py
+++ b/src/refred/plot/display_plots.py
@@ -363,6 +363,14 @@ class DisplayPlots(object):
         parent.ui.TOFmanualToValue.setText(stmax)
 
     def workWithNorm(self, update_reduction_table=True):
+        """
+        Update instance attributes to point to the normalization tab plot widgets
+
+        Parameters
+        ----------
+        update_reduction_table: bool
+            If True, updates the background settings widgets in the normalization tab
+        """
         parent = self.parent
         self.yt_plot_ui = parent.ui.norm_yt_plot
         self.yi_plot_ui = parent.ui.norm_yi_plot
@@ -388,6 +396,17 @@ class DisplayPlots(object):
             parent.ui.normLowResFlag.setChecked(self.lowResFlag)
 
     def workWithData(self, update_reduction_table=True):
+        """
+        Update instance attributes to point to the data tab plot widgets
+
+        Optionally updates the background setting widgets according to the plotted run configuration,
+        while blocking the widget signals to not trigger additional plot updates.
+
+        Parameters
+        ----------
+        update_reduction_table: bool
+            If True, updates the background settings widgets in the data tab
+        """
         parent = self.parent
         self.yt_plot_ui = parent.ui.data_yt_plot
         self.yi_plot_ui = parent.ui.data_yi_plot
@@ -396,19 +415,42 @@ class DisplayPlots(object):
 
         if update_reduction_table:
             [peak1, peak2] = self.peak
+            parent.ui.peakFromValue.blockSignals(True)
             parent.ui.peakFromValue.setValue(peak1)
+            parent.ui.peakFromValue.blockSignals(False)
+
+            parent.ui.peakToValue.blockSignals(True)
             parent.ui.peakToValue.setValue(peak2)
+            parent.ui.peakToValue.blockSignals(False)
 
+            parent.ui.backFromValue.blockSignals(True)
             parent.ui.backFromValue.setValue(self.back[0])
-            parent.ui.backToValue.setValue(self.back[1])
+            parent.ui.backFromValue.blockSignals(False)
 
+            parent.ui.backToValue.blockSignals(True)
+            parent.ui.backToValue.setValue(self.back[1])
+            parent.ui.backToValue.blockSignals(False)
+
+            parent.ui.back2FromValue.blockSignals(True)
             parent.ui.back2FromValue.setValue(self.back2[0])
+            parent.ui.back2FromValue.blockSignals(False)
+
+            parent.ui.back2ToValue.blockSignals(True)
             parent.ui.back2ToValue.setValue(self.back2[1])
+            parent.ui.back2ToValue.blockSignals(False)
 
             [lowRes1, lowRes2] = self.lowRes
+            parent.ui.dataLowResFromValue.blockSignals(True)
             parent.ui.dataLowResFromValue.setValue(lowRes1)
+            parent.ui.dataLowResFromValue.blockSignals(False)
+
+            parent.ui.dataLowResToValue.blockSignals(True)
             parent.ui.dataLowResToValue.setValue(lowRes2)
+            parent.ui.dataLowResToValue.blockSignals(False)
+
+            parent.ui.dataLowResFlag.blockSignals(True)
             parent.ui.dataLowResFlag.setChecked(self.lowResFlag)
+            parent.ui.dataLowResFlag.blockSignals(False)
 
     def isDataSelected(self):
         if self.parent.ui.dataNormTabWidget.currentIndex() == 0:

--- a/test/unit/refred/autopopulatemaintable/test_reductiontable_auto_fill.py
+++ b/test/unit/refred/autopopulatemaintable/test_reductiontable_auto_fill.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+from refred.autopopulatemaintable.reductiontable_auto_fill import ReductionTableAutoFill
+from refred.calculations.lr_data import LRData
+from refred.gui_handling.data_norm_spinboxes import DataSpinbox
+from refred.main import MainGui
+from refred.reduction_table_handling.reduction_table_check_box import ReductionTableCheckBox
+
+
+@mock.patch("refred.calculations.locate_list_run.FileFinder.findRuns")
+def test_reduction_table_auto_fill_two_runs(mock_file_finder_find_runs, file_finder_find_runs, qtbot):
+    """Test that the first run configuration is preserved when loading a second run"""
+    mock_file_finder_find_runs.side_effect = file_finder_find_runs
+
+    window_main = MainGui()
+    qtbot.addWidget(window_main)
+
+    # load the first run and plot it
+    run_str_1 = "188300"
+    ReductionTableAutoFill(parent=window_main, list_of_run_from_input=run_str_1, data_type_selected="data")
+    ReductionTableCheckBox(parent=window_main, row_selected=0)
+
+    # modify the background position
+    back_min, back_max = 120, 180
+    DataSpinbox(parent=window_main, entry_type="back", value_min=back_min, value_max=back_max)
+
+    # verify that the background position was updated
+    run_data: LRData = window_main.big_table_data.reflectometry_data(0)
+    assert run_data.run_number == run_str_1
+    assert run_data.back == [back_min, back_max]
+
+    # load the second run, which will bump the first run to the second row due to the sorting by lambda
+    run_str_2 = "188299"
+    ReductionTableAutoFill(parent=window_main, list_of_run_from_input=run_str_2, data_type_selected="data")
+
+    # verify that the background position of the first run (now in the second row in the table) is the same
+    run_data: LRData = window_main.big_table_data.reflectometry_data(1)
+    assert run_data.run_number == run_str_1
+    assert run_data.back == [back_min, back_max]

--- a/test/unit/refred/autopopulatemaintable/test_reductiontable_auto_fill.py
+++ b/test/unit/refred/autopopulatemaintable/test_reductiontable_auto_fill.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from refred.autopopulatemaintable.reductiontable_auto_fill import ReductionTableAutoFill
 from refred.calculations.lr_data import LRData
-from refred.gui_handling.data_norm_spinboxes import DataSpinbox
+from refred.gui_handling.data_norm_spinboxes import DataSpinbox, NormSpinbox
 from refred.main import MainGui
 from refred.reduction_table_handling.reduction_table_check_box import ReductionTableCheckBox
 
@@ -15,25 +15,36 @@ def test_reduction_table_auto_fill_two_runs(mock_file_finder_find_runs, file_fin
     window_main = MainGui()
     qtbot.addWidget(window_main)
 
-    # load the first run and plot it
-    run_str_1 = "188300"
+    # load the first data run + normalization run and plot
+    run_str_1 = "188299"
+    norm_str_1 = "188231"
     ReductionTableAutoFill(parent=window_main, list_of_run_from_input=run_str_1, data_type_selected="data")
+    ReductionTableAutoFill(parent=window_main, list_of_run_from_input=norm_str_1, data_type_selected="norm")
     ReductionTableCheckBox(parent=window_main, row_selected=0)
 
-    # modify the background position
+    # modify the background position for the data run and normalization run
     back_min, back_max = 120, 180
     DataSpinbox(parent=window_main, entry_type="back", value_min=back_min, value_max=back_max)
+    NormSpinbox(parent=window_main, entry_type="back", value_min=back_min, value_max=back_max)
 
     # verify that the background position was updated
     run_data: LRData = window_main.big_table_data.reflectometry_data(0)
     assert run_data.run_number == run_str_1
     assert run_data.back == [back_min, back_max]
+    norm_data: LRData = window_main.big_table_data.normalization_data(0)
+    assert norm_data.run_number == norm_str_1
+    assert norm_data.back == [back_min, back_max]
 
     # load the second run, which will bump the first run to the second row due to the sorting by lambda
-    run_str_2 = "188299"
+    run_str_2 = "188300"
     ReductionTableAutoFill(parent=window_main, list_of_run_from_input=run_str_2, data_type_selected="data")
+    window_main.norm_sequence_event()
 
     # verify that the background position of the first run (now in the second row in the table) is the same
-    run_data: LRData = window_main.big_table_data.reflectometry_data(1)
+    run_data: LRData = window_main.big_table_data.reflectometry_data(0)
     assert run_data.run_number == run_str_1
     assert run_data.back == [back_min, back_max]
+    # TODO: making this pass requires refactoring of ReductionTableAutoFill, see follow up defect EWM 13195
+    # norm_data: LRData = window_main.big_table_data.normalization_data(0)
+    # assert norm_data.run_number == norm_str_1
+    # assert norm_data.back == [back_min, back_max]


### PR DESCRIPTION
## Description of work:

This fixes two scenarios that give rise to wrong ROI ranges:
1. Changing the ROI for the plotted run and then plotting another run. Previously, this would make the ROI ranges displayed in the config widget and the ROI plotted out-of-sync.
2. Loading one run, changing its ROI, then loading another run. Previously, this would reset the ROI ranges.

Check all that apply:

- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~
- [ ] ~~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~~
- [ ] ~~updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)~~

**References:**

- Links to IBM EWM items: [Defect 12851: [RefRed] Scenarios giving rise to out-of-sync between ROI ranges in the data tab plots and the numerical values displayed](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=12851)
- Links to related issues or pull requests:

## :warning:  Manual test for the reviewer

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

Start RefRed GUI

```bash
(refred)
$ PYTHONPATH=$(pwd):$PYTHONPATH ./scripts/start_refred.py
```

Or run tests

```bash
$ pixi run test
```

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
