### PR TITLE
Clear reduction table row if both the data run and normalization run cells are cleared

### DIFF
--- a/src/refred/reduction_table_handling/reduction_table_handler.py
+++ b/src/refred/reduction_table_handling/reduction_table_handler.py
@@ -28,8 +28,22 @@ class ReductionTableHandler(object):
         self.parent.ui.previewLive.setEnabled(False)
         self.parent.ui.actionExportScript.setEnabled(False)
 
-    def clear_rows_selected(self):
-        self.__get_range_row_selected()
+    def clear_rows_selected(self, row_index: int | None = None):
+        """Clear reduction table row(s) in GUI and internal state
+
+        Parameters
+        ----------
+        row_index
+            The row to clear. If None, uses the current GUI selection.
+        """
+        if row_index is None:
+            # Determine row range from current GUI selection
+            self.__get_range_row_selected()
+        else:
+            if not isinstance(row_index, int):
+                raise TypeError(f"row_index must be an int or None, got {type(row_index)}")
+            self.from_row = self.to_row = row_index
+
         if self.__is_row_displayed_in_range_selected():
             self.__clear_metadata()
             self.__clear_plots()

--- a/src/refred/reduction_table_handling/update_reduction_table.py
+++ b/src/refred/reduction_table_handling/update_reduction_table.py
@@ -6,6 +6,7 @@ from refred.calculations.check_list_run_compatibility_thread import CheckListRun
 from refred.calculations.locate_list_run import LocateListRun
 from refred.calculations.run_sequence_breaker import RunSequenceBreaker
 from refred.interfaces.mytablewidget import ReductionTableColumnIndex
+from refred.reduction_table_handling.reduction_table_handler import ReductionTableHandler
 from refred.tabledata import TableData
 
 
@@ -89,10 +90,16 @@ class UpdateReductionTable(object):
         if config is None:
             # no data loaded in this row
             return
-        if self.col == 1:
+        data_item = self.parent.ui.reductionTable.item(self.row, ReductionTableColumnIndex.DATA_RUN)
+        norm_item = self.parent.ui.reductionTable.item(self.row, ReductionTableColumnIndex.NORM_RUN)
+        if data_item.text() == "" and norm_item.text() == "":
+            # clear the whole row since both the data run and norm run are empty
+            o_reduction_table_handler = ReductionTableHandler(parent=self.parent)
+            o_reduction_table_handler.clear_rows_selected(self.row)
+        elif self.col == ReductionTableColumnIndex.DATA_RUN:
             big_table_data.set_reflectometry_data(self.row, None)
             config.clear_data()
-        elif self.col == 2:
+        elif self.col == ReductionTableColumnIndex.NORM_RUN:
             big_table_data.set_normalization_data(self.row, None)
             config.clear_normalization()
 

--- a/test/unit/refred/reduction/test_live_reduction_handler.py
+++ b/test/unit/refred/reduction/test_live_reduction_handler.py
@@ -1,10 +1,15 @@
+from unittest import mock
+
 from refred.main import MainGui
 from refred.reduction.live_reduction_handler import LiveReductionHandler
 from test.utilities import load_run_from_reduction_table
 
 
 class TestLiveReductionHandler:
-    def test_run(self, qtbot):
+    @mock.patch("refred.calculations.locate_list_run.FileFinder.findRuns")
+    def test_run(self, mock_file_finder_find_runs, qtbot, file_finder_find_runs):
+        mock_file_finder_find_runs.side_effect = file_finder_find_runs
+
         main_window = MainGui()
         qtbot.addWidget(main_window)
         main_window.ui.useNormalizationFlag.setChecked(False)

--- a/test/unit/refred/reduction_table_handling/test_reduction_table_handling.py
+++ b/test/unit/refred/reduction_table_handling/test_reduction_table_handling.py
@@ -84,3 +84,29 @@ class TestReductionTableHandling:
         for i in range(NBR_ROWS - nbr_deleted, NBR_ROWS):
             assert table.item(i, ReductionTableColumnIndex.DATA_RUN).text() == ""
             assert table.item(i, ReductionTableColumnIndex.NORM_RUN).text() == ""
+
+    @pytest.mark.parametrize(
+        "row_index, throws_exception",
+        [
+            (None, False),
+            (2, False),
+            ([2, 3], True),
+        ],
+    )
+    def test_clear_rows_selected_row_index(self, row_index, throws_exception, setup_main_window_reduction_table, qtbot):
+        """Test clear_rows_selected with different inputs"""
+        window_main = setup_main_window_reduction_table
+        qtbot.addWidget(window_main)
+        from_row = 2
+        to_row = 3  # inclusive
+
+        with mock.patch.object(ReductionTableHandler, "_ReductionTableHandler__get_range_row_selected"):
+            handler = ReductionTableHandler(parent=window_main)
+            handler.from_row = from_row
+            handler.to_row = to_row
+
+            if throws_exception:
+                with pytest.raises(TypeError):
+                    handler.clear_rows_selected(row_index=row_index)
+            else:
+                handler.clear_rows_selected(row_index=row_index)

--- a/test/unit/refred/reduction_table_handling/test_update_reduction_table.py
+++ b/test/unit/refred/reduction_table_handling/test_update_reduction_table.py
@@ -3,7 +3,9 @@ import unittest.mock as mock
 # third party packages
 import pytest
 
+from refred.interfaces.mytablewidget import ReductionTableColumnIndex as TableCol
 from refred.main import MainGui
+from refred.tabledata import TableDataColumIndex
 from test.utilities import load_run_from_reduction_table
 
 wait = 2000
@@ -107,6 +109,41 @@ def test_load_run_auto_peak_finder(mock_file_finder_find_runs, mock_display_plot
     assert window_main.big_table_data[0, 0].peak == user_set_peak
     assert window_main.big_table_data[0, 0].back == user_set_back
     assert window_main.big_table_data[0, 0].tof_range_auto == pytest.approx(user_set_tof, 1e-6)
+
+
+@mock.patch("refred.calculations.locate_list_run.FileFinder.findRuns")
+def test_clear_row_when_both_data_and_norm_runs_cleared(mock_file_finder_find_runs, qtbot, file_finder_find_runs):
+    """Test that the row is cleared when both the data run and the normalization run have been cleared"""
+    mock_file_finder_find_runs.side_effect = file_finder_find_runs
+
+    window_main = MainGui()
+    qtbot.addWidget(window_main)
+
+    row = 0
+    reflected_run = "188300"
+    load_run_from_reduction_table(window_main, row=row, col=TableCol.DATA_RUN, run=reflected_run)
+    qtbot.wait(wait)
+
+    normalization_run = "188232"
+    load_run_from_reduction_table(window_main, row=row, col=TableCol.NORM_RUN, run=normalization_run)
+    qtbot.wait(wait)
+
+    # clear the text in the data run and normalization run cells
+    load_run_from_reduction_table(window_main, row=row, col=TableCol.DATA_RUN, run="")
+    load_run_from_reduction_table(window_main, row=row, col=TableCol.NORM_RUN, run="")
+
+    # verify that the internal state has been cleared
+    assert window_main.big_table_data.get_data_by_column_enum(row, TableDataColumIndex.LR_DATA) is None
+    assert window_main.big_table_data.get_data_by_column_enum(row, TableDataColumIndex.LR_NORM) is None
+    assert window_main.big_table_data.get_data_by_column_enum(row, TableDataColumIndex.LR_CONFIG) is None
+
+    # verify that the GUI row has been cleared
+    ui_table = window_main.ui.reductionTable
+    _nbr_col = ui_table.columnCount()
+    for col_index in range(_nbr_col):
+        item = ui_table.item(row, col_index)
+        if item:
+            assert item.text() == ""
 
 
 if __name__ == "__main__":

--- a/test/unit/refred/reduction_table_handling/test_update_reduction_table.py
+++ b/test/unit/refred/reduction_table_handling/test_update_reduction_table.py
@@ -131,6 +131,7 @@ def test_clear_row_when_both_data_and_norm_runs_cleared(mock_file_finder_find_ru
     # clear the text in the data run and normalization run cells
     load_run_from_reduction_table(window_main, row=row, col=TableCol.DATA_RUN, run="")
     load_run_from_reduction_table(window_main, row=row, col=TableCol.NORM_RUN, run="")
+    qtbot.wait(wait)
 
     # verify that the internal state has been cleared
     assert window_main.big_table_data.get_data_by_column_enum(row, TableDataColumIndex.LR_DATA) is None


### PR DESCRIPTION
## Description of work:

The users often want to keep the row, while swapping out either the reflected run or the normalization run by editing the run number in the cell. However, if both the reflected run and the normalization run have been cleared, the whole row should be cleared. (Another option for clearing a row is the right-click option on the row, however, one has to right-click in one of the non-editable cells to see the right-click menu.)

Check all that apply:

- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)

**References:**

- Links to IBM EWM items: [Defect 13226: [RefRed] Deleting run and normalization values from the table doesn't completely remove values](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13226)
- Links to related issues or pull requests:

## :warning:  Manual test for the reviewer

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

1. Load data and normalization runs, for example using the template file `test/data/REF_L_188299_to_188301_plus_norm_runs.xml`.
2. Test deleting either the number in the "Data Run #" or "Norm. Run #". The row should only be totally cleared if both cells are empty for the row.

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
