### PR TITLE
Pin numpy version

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4546,8 +4546,8 @@ packages:
   timestamp: 1760379115194
 - pypi: ./
   name: refred
-  version: 5.8.0rc1
-  sha256: b846b70b1db068713b713a95be6489a98fb4db17dbff48f7109e7c2b3634f27a
+  version: 5.8.0rc2
+  sha256: 8ceb34df0d39052d8f2ad5f52f8963ab08f56d381086fdd5379fa8e5817ba29f
   requires_python: '>=3.11,<3.12'
   editable: true
 - pypi: https://files.pythonhosted.org/packages/5e/48/58a1f6623466522352a6efa153b9a3714fc559d9f930e9bc947b4a88a2c3/regex-2025.10.23-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ backend = { name = "pixi-build-python", version = "0.1.*" }
 [tool.pixi.dependencies]
 lr_reduction = "=2.6.0"
 configobj = ">=5.0.9"
+numpy = "2.1.*"
 
 [tool.pixi.pypi-dependencies]
 refred = { path = ".", editable = true }
@@ -90,7 +91,7 @@ refred = { path = ".", editable = true }
 [tool.pixi.package.run-dependencies]
 lr_reduction = "=2.6.0"
 configobj = ">=5.0.9"
-
+numpy = "2.1.*"
 [tool.pixi.package.host-dependencies]
 python = ">=3.11,<3.12"  # Python version to build the package with
 hatchling = "*"


### PR DESCRIPTION
## Description of work:
A bug introduced likely when upgrading mantid caused the numpy version to upgrade causing an error at runtime. This PR just pins the version to use the working version run under pixi.

Check all that apply:

- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)

**References:**

- Links to IBM EWM items: [14249: fix numpy error](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14249)
- Links to related issues or pull requests:

## :warning:  Manual test for the reviewer

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
