### PR TITLE
Fix Reduction Table Locking on Invalid Run

### DIFF
--- a/src/refred/reduction_table_handling/update_reduction_table.py
+++ b/src/refred/reduction_table_handling/update_reduction_table.py
@@ -36,6 +36,7 @@ class UpdateReductionTable(object):
         # check if nexus can be found
         list_run_object = LocateListRun(list_run=list_run)
         col_comments = ReductionTableColumnIndex.COMMENTS
+
         if list_run_object.list_run_not_found != []:
             str_list_run_not_found = [str(x) for x in list_run_object.list_run_not_found]
             runs_not_located = ", ".join(str_list_run_not_found)
@@ -53,6 +54,8 @@ class UpdateReductionTable(object):
 
         if list_run_found == []:
             self.parent.ui.reductionTable.item(row, col).setText("")
+            self.parent.file_loaded_signal.emit(row, self.is_data_displayed, self.display_of_this_row_checked())
+            QApplication.processEvents()
             return
         str_list_run_found = [str(x) for x in list_run_found]
         final_list_run_found = ",".join(str_list_run_found)


### PR DESCRIPTION
## Description of work:
The reduction table would lock refred when an invalid run number was entered. This PR emits a signal in the event a run is not found, solving the defect.

Check all that apply:

- [X] Source added/refactored
- [] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)

**References:**

- Links to IBM EWM items: [13225: [RefRed] Invalid entries into the run table locks RefRed](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/13225)
- Links to related issues or pull requests:

## :warning:  Manual test for the reviewer
Open `refred-gui` and enter an invalid run number in the reduction table. Confirm the application does not lock up.

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
