### PR TITLE
Fixed - Normalization ROI Resets When Loading New Data Run

### DIFF
--- a/src/refred/autopopulatemaintable/populate_reduction_table_from_list_lrdata.py
+++ b/src/refred/autopopulatemaintable/populate_reduction_table_from_list_lrdata.py
@@ -41,7 +41,7 @@ class PopulateReductionTableFromListLRData(object):
         self.insert_runs_into_table()
 
         if is_data:
-            self.clear_big_table_data()
+            self.clear_big_table_data(preserve_norm=True)
             self.update_big_table_data()
 
         self.parent.big_table_data = self.big_table_data
@@ -119,5 +119,12 @@ class PopulateReductionTableFromListLRData(object):
                 str_run = str(_run)
             self.parent.ui.reductionTable.item(_index, self.reductionTable_col).setText(str_run)
 
-    def clear_big_table_data(self):
-        self.big_table_data = TableData(self.parent.REDUCTIONTABLE_MAX_ROWCOUNT)
+    def clear_big_table_data(self, preserve_norm=False):
+        """
+        preserve_norm : bool - Whether to preserve the norm run column.
+            Used to persist LRData information during run loading process.
+        """
+        new_table = TableData(self.parent.REDUCTIONTABLE_MAX_ROWCOUNT)
+        if preserve_norm:
+            new_table[:, 1] = self.big_table_data[:, 1]
+        self.big_table_data = new_table

--- a/test/unit/refred/autopopulatemaintable/test_reductiontable_auto_fill.py
+++ b/test/unit/refred/autopopulatemaintable/test_reductiontable_auto_fill.py
@@ -44,7 +44,6 @@ def test_reduction_table_auto_fill_two_runs(mock_file_finder_find_runs, file_fin
     run_data: LRData = window_main.big_table_data.reflectometry_data(0)
     assert run_data.run_number == run_str_1
     assert run_data.back == [back_min, back_max]
-    # TODO: making this pass requires refactoring of ReductionTableAutoFill, see follow up defect EWM 13195
-    # norm_data: LRData = window_main.big_table_data.normalization_data(0)
-    # assert norm_data.run_number == norm_str_1
-    # assert norm_data.back == [back_min, back_max]
+    norm_data: LRData = window_main.big_table_data.normalization_data(0)
+    assert norm_data.run_number == norm_str_1
+    assert norm_data.back == [back_min, back_max]


### PR DESCRIPTION
## Description of work:

A defect was found with the following usage:
1. load data run using the text box
2. load normalization run using the text box
3. switch to normalization tab
4. modify the spinboxes for background (righthand side)
5. load new data run using the text box
6. observe the spinbox value was reset.

Tracing the execution of loading this second data run found the culprit to be 

[call](https://github.com/neutrons/RefRed/blob/882ead709647f7497f1f1e0f552d7c66be769108/src/refred/autopopulatemaintable/populate_reduction_table_from_list_lrdata.py#L44)
[PopulateReductionTableFromListLRData::clear_big_table_data](https://github.com/neutrons/RefRed/blob/882ead709647f7497f1f1e0f552d7c66be769108/src/refred/autopopulatemaintable/reductiontable_auto_fill.py#L321)
[ReductionTableAutoFill::updating_reductionTable](https://github.com/neutrons/RefRed/blob/882ead709647f7497f1f1e0f552d7c66be769108/src/refred/autopopulatemaintable/reductiontable_auto_fill.py#L147)

Upon loading a new run, all runs are reloaded. However, there is no mechanism to reload any existing configuration of the LRData objects causing the reload to re-initialize configurations leading to the spinbox value reset.

The solution is to wait to clear the normalization runs column until data runs are processed. This allows copying of configuration data.


Check all that apply:

- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)

**References:**

- Links to IBM EWM items: [13195: [RefRed] Normalization run ROI reset when loading new data run](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/13195)
- Links to related issues or pull requests: #186 

## :warning:  Manual test for the reviewer

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
