### PR TITLE
Order Data Stitching Tab Runs by Increasing Q

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -8,8 +8,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -126,8 +124,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -484,8 +480,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -4552,9 +4546,10 @@ packages:
   timestamp: 1760379115194
 - pypi: ./
   name: refred
-  version: 5.9.0.dev31
+  version: 5.10.0.dev2
   sha256: 0a3025b865fd205b26e5f184a637fff730d6569d9ec84d7229ffdf3ad36dd91d
   requires_python: '>=3.11,<3.12'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/bd/3d/22a4eaba214a917c80e04f6025d26143690f0419511e0116508e24b11c9b/regex-2025.11.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: regex
   version: 2025.11.3

--- a/src/refred/export/export_plot_ascii.py
+++ b/src/refred/export/export_plot_ascii.py
@@ -220,18 +220,20 @@ class ExportPlotAscii:
     def write_output_file(self, file_path):
         """
         Collect all the reduced data and create an output file.
+        Runs are exported in ascending q-value order.
         """
         # Gather data
-        o_gui_utility = GuiUtility(parent=self.parent)
-        nbr_row = o_gui_utility.reductionTable_nbr_row()
         o_reduced_data_hanlder = ReducedDataHandler(parent=self.parent)
 
         # Check wheter we want to export each individual run
         export_all = self.parent.ui.export_individual_checkbox.isChecked()
         _root, _ext = os.path.splitext(file_path)
 
+        # Get q-sorted row indices
+        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
+
         coll = lr_output.RunCollection()
-        for row in range(nbr_row):
+        for export_index, row in enumerate(sorted_indices):
             _data = self.parent.big_table_data.reduction_config(row)
 
             # Get the scaling factor, which may change in the UI
@@ -251,7 +253,7 @@ class ExportPlotAscii:
 
             # At the user's request, save each individual run
             if export_all:
-                run_file_path = "%s-%d%s" % (_root, row, _ext)
+                run_file_path = "%s-%d%s" % (_root, export_index, _ext)
                 coll_run = lr_output.RunCollection()
                 coll_run.add(qz_mid, refl, d_refl, meta_data=_data.meta_data)
                 coll_run.save_ascii(run_file_path)

--- a/src/refred/export/export_plot_ascii.py
+++ b/src/refred/export/export_plot_ascii.py
@@ -233,7 +233,7 @@ class ExportPlotAscii:
         sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
 
         coll = lr_output.RunCollection()
-        for export_index, row in enumerate(sorted_indices):
+        for row in sorted_indices:
             _data = self.parent.big_table_data.reduction_config(row)
 
             # Get the scaling factor, which may change in the UI
@@ -253,7 +253,7 @@ class ExportPlotAscii:
 
             # At the user's request, save each individual run
             if export_all:
-                run_file_path = "%s-%d%s" % (_root, export_index, _ext)
+                run_file_path = "%s-%d%s" % (_root, row, _ext)
                 coll_run = lr_output.RunCollection()
                 coll_run.add(qz_mid, refl, d_refl, meta_data=_data.meta_data)
                 coll_run.save_ascii(run_file_path)

--- a/src/refred/gui_handling/fill_stitching_table.py
+++ b/src/refred/gui_handling/fill_stitching_table.py
@@ -18,8 +18,19 @@ class FillStitchingTable(ParentHandler):
         super(FillStitchingTable, self).__init__(parent=parent)
         self.row_index = row_index
 
-    def fillRow(self, row_index=0):
+    def fillRow(self, row_index=0, stitching_row=None):
+        """Fill a row in the stitching table.
+
+        Parameters
+        ----------
+        row_index : int
+            The row index in big_table_data to read the reduction config from.
+        stitching_row : int or None
+            The row index in the stitching table GUI to write to.
+            If None, defaults to row_index (original behavior).
+        """
         self._row_index = row_index
+        self._stitching_row = stitching_row if stitching_row is not None else row_index
         self._lconfig = self.big_table_data.reduction_config(self._row_index)
         if self._lconfig is None:
             return
@@ -40,7 +51,7 @@ class FillStitchingTable(ParentHandler):
         _run_number = self.parent.ui.reductionTable.item(self._row_index, 1).text()
         _run_item = QtWidgets.QTableWidgetItem(_run_number)
         _run_item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
-        self.parent.ui.dataStitchingTable.setItem(self._row_index, 0, _run_item)
+        self.parent.ui.dataStitchingTable.setItem(self._stitching_row, 0, _run_item)
 
     def fillTableForAbsoluteNormalization(self):
         _sf = self._lconfig.sf_abs_normalization
@@ -59,7 +70,7 @@ class FillStitchingTable(ParentHandler):
         _auto_item = QtWidgets.QTableWidgetItem(sf)
         _auto_item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
         _auto_item.setForeground(_color)
-        self.parent.ui.dataStitchingTable.setItem(self._row_index, 1, _auto_item)
+        self.parent.ui.dataStitchingTable.setItem(self._stitching_row, 1, _auto_item)
 
     def fillTableForManualStitching(self):
         try:
@@ -75,4 +86,4 @@ class FillStitchingTable(ParentHandler):
         _widget_manual.setSingleStep(0.001)
         _widget_manual.setDecimals(6)
         _widget_manual.valueChanged.connect(self.parent.data_stitching_table_manual_spin_box)
-        self.parent.ui.dataStitchingTable.setCellWidget(self._row_index, 1, _widget_manual)
+        self.parent.ui.dataStitchingTable.setCellWidget(self._stitching_row, 1, _widget_manual)

--- a/src/refred/reduction/live_reduced_data_handler.py
+++ b/src/refred/reduction/live_reduced_data_handler.py
@@ -12,25 +12,43 @@ class LiveReducedDataHandler(object):
     colors = None
     row_index = 0
 
-    def __init__(self, parent=None, row_index=0):
+    def __init__(self, parent=None, row_index=0, rows_processed=None):
         self.parent = parent
         self.big_table_data: TableData = self.parent.big_table_data  # type: ignore
         self.colors = refred.colors.COLOR_LIST
         self.row_index = row_index
+        # rows_processed is the list of big_table_data row indices that have
+        # been reduced so far (in the order they were processed, which should
+        # be q-sorted order).  When None we fall back to computing it.
+        self._rows_processed = rows_processed
+
+    def _get_rows_to_display(self):
+        """Return the q-sorted row indices that should currently be shown."""
+        if self._rows_processed is not None:
+            # Already in q-sorted order as provided by the caller
+            return list(self._rows_processed)
+        # Fallback: compute from big_table_data, filtered to rows <= row_index
+        sorted_indices = self.big_table_data.get_q_sorted_indices()
+        return [i for i in sorted_indices if i <= self.row_index]
 
     def populate_table(self):
-        self.clear_stiching_table()
-        o_fill_table = FillStitchingTable(parent=self.parent)
-        o_fill_table.fillRow(row_index=self.row_index)
+        rows = self._get_rows_to_display()
+        is_first = len(rows) == 1 and rows[0] == self.row_index
+        self.clear_stiching_table(is_first=is_first)
 
-        if self.row_index == 0:
+        o_fill_table = FillStitchingTable(parent=self.parent)
+        # Re-fill the entire stitching table in q-sorted order
+        for stitching_row, original_row in enumerate(rows):
+            o_fill_table.fillRow(row_index=original_row, stitching_row=stitching_row)
+
+        if is_first:
             self.activate_stitching_tab()
 
     def activate_stitching_tab(self):
         self.parent.ui.plotTab.setCurrentIndex(1)
 
-    def clear_stiching_table(self):
-        if self.row_index == 0:
+    def clear_stiching_table(self, is_first=False):
+        if is_first:
             o_gui_utility = GuiUtility(parent=self.parent)
             o_gui_utility.clear_table(self.parent.ui.dataStitchingTable)
 
@@ -40,8 +58,10 @@ class LiveReducedDataHandler(object):
         big_table_data = self.big_table_data
         _data = big_table_data[0, 0]
 
-        for index_row in range(self.row_index + 1):
-            _lconfig = big_table_data.reduction_config(index_row)
+        rows = self._get_rows_to_display()
+
+        for color_index, original_row in enumerate(rows):
+            _lconfig = big_table_data.reduction_config(original_row)
             if _lconfig is None:
                 return
 
@@ -64,7 +84,7 @@ class LiveReducedDataHandler(object):
             e_axis = o_produce_output.output_e_axis
 
             self.parent.ui.data_stitching_plot.errorbar(
-                _q_axis, y_axis, yerr=e_axis, color=self.get_current_color_plot(index_row)
+                _q_axis, y_axis, yerr=e_axis, color=self.get_current_color_plot(color_index)
             )
 
             if _data.all_plot_axis.is_reduced_plot_stitching_tab_ylog:
@@ -79,38 +99,41 @@ class LiveReducedDataHandler(object):
             QApplication.processEvents()
 
     def live_plot(self):
-        if self.row_index == 0:
-            self.parent.ui.data_stitching_plot.clear()
-            self.parent.ui.data_stitching_plot.draw()
-
         big_table_data = self.big_table_data
         _data = big_table_data[0, 0]
 
-        _lconfig = big_table_data[self.row_index, 2]
-        if _lconfig is None:
-            return
+        rows = self._get_rows_to_display()
 
-        _q_axis = _lconfig.q_axis_for_display.copy()
-        _y_axis = _lconfig.y_axis_for_display.copy()
-        _e_axis = _lconfig.e_axis_for_display.copy()
-        sf = self.generate_selected_sf(lconfig=_lconfig)
+        # Clear and re-draw all runs processed so far in q-sorted order
+        self.parent.ui.data_stitching_plot.clear()
+        self.parent.ui.data_stitching_plot.draw()
 
-        _y_axis = np.array(_y_axis, dtype=float)
-        _e_axis = np.array(_e_axis, dtype=float)
+        for color_index, original_row in enumerate(rows):
+            _lconfig = big_table_data[original_row, 2]
+            if _lconfig is None:
+                return
 
-        _y_axis = _y_axis * sf
-        _e_axis = _e_axis * sf
+            _q_axis = _lconfig.q_axis_for_display.copy()
+            _y_axis = _lconfig.y_axis_for_display.copy()
+            _e_axis = _lconfig.e_axis_for_display.copy()
+            sf = self.generate_selected_sf(lconfig=_lconfig)
 
-        o_produce_output = ProducedSelectedOutputScaled(
-            parent=self.parent, q_axis=_q_axis, y_axis=_y_axis, e_axis=_e_axis
-        )
-        o_produce_output.calculate()
-        y_axis = o_produce_output.output_y_axis
-        e_axis = o_produce_output.output_e_axis
+            _y_axis = np.array(_y_axis, dtype=float)
+            _e_axis = np.array(_e_axis, dtype=float)
 
-        self.parent.ui.data_stitching_plot.errorbar(
-            _q_axis, y_axis, yerr=e_axis, color=self.get_current_color_plot(self.row_index)
-        )
+            _y_axis = _y_axis * sf
+            _e_axis = _e_axis * sf
+
+            o_produce_output = ProducedSelectedOutputScaled(
+                parent=self.parent, q_axis=_q_axis, y_axis=_y_axis, e_axis=_e_axis
+            )
+            o_produce_output.calculate()
+            y_axis = o_produce_output.output_y_axis
+            e_axis = o_produce_output.output_e_axis
+
+            self.parent.ui.data_stitching_plot.errorbar(
+                _q_axis, y_axis, yerr=e_axis, color=self.get_current_color_plot(color_index)
+            )
 
         if _data.all_plot_axis.is_reduced_plot_stitching_tab_ylog:
             self.parent.ui.data_stitching_plot.set_yscale("log")

--- a/src/refred/reduction/live_reduced_data_handler.py
+++ b/src/refred/reduction/live_reduced_data_handler.py
@@ -109,7 +109,7 @@ class LiveReducedDataHandler(object):
         self.parent.ui.data_stitching_plot.draw()
 
         for color_index, original_row in enumerate(rows):
-            _lconfig = big_table_data[original_row, 2]
+            _lconfig = big_table_data.reduction_config(original_row)
             if _lconfig is None:
                 return
 

--- a/src/refred/reduction/live_reduction_handler.py
+++ b/src/refred/reduction/live_reduction_handler.py
@@ -37,7 +37,13 @@ class LiveReductionHandler(object):
         self.nbr_reduction_process = self.calculate_nbr_reduction_process()
 
     def recalculate(self, replot_only=False):
-        for row_index in range(self.nbr_reduction_process):
+        # Process runs in q-sorted order so auto stitching finds correct neighbors
+        sorted_indices = self.big_table_data.get_q_sorted_indices()
+        rows_processed_so_far = []
+
+        for row_index in sorted_indices:
+            rows_processed_so_far.append(row_index)
+
             # scale
             if not replot_only:
                 o_calculate_sf = LiveCalculateSF(
@@ -48,7 +54,11 @@ class LiveReductionHandler(object):
                 o_calculate_sf.run()
 
             # plot
-            o_reduced_plot = LiveReducedDataHandler(parent=self.parent, row_index=row_index)
+            o_reduced_plot = LiveReducedDataHandler(
+                parent=self.parent,
+                row_index=row_index,
+                rows_processed=list(rows_processed_so_far),
+            )
             o_reduced_plot.populate_table()
             o_reduced_plot.live_plot()
 
@@ -75,6 +85,7 @@ class LiveReductionHandler(object):
 
         common_pars = GlobalReductionSettingsHandler(parent=self.parent).to_dict()
 
+        # First pass: run all reductions (order doesn't matter for the reduction itself)
         for row_index in range(self.nbr_reduction_process):
             # Reduction options to pass as template data
             reduction_pars = IndividualReductionSettingsHandler(parent=self.parent, row_index=row_index).to_dict()
@@ -100,18 +111,29 @@ class LiveReductionHandler(object):
                 )
                 return
 
+            o_reduction_progressbar_handler.next_step()
+
+        # Second pass: scale and plot in q-sorted order so auto stitching works correctly
+        sorted_indices = self.big_table_data.get_q_sorted_indices()
+        rows_processed_so_far = []
+
+        for row_index in sorted_indices:
+            rows_processed_so_far.append(row_index)
+
             # scale
             o_calculate_sf = LiveCalculateSF(parent=self.parent, row_index=row_index)
             o_calculate_sf.run()
 
             # plot
-            o_reduced_plot = LiveReducedDataHandler(parent=self.parent, row_index=row_index)
+            o_reduced_plot = LiveReducedDataHandler(
+                parent=self.parent,
+                row_index=row_index,
+                rows_processed=list(rows_processed_so_far),
+            )
             o_reduced_plot.populate_table()
             o_reduced_plot.live_plot()
             self.parent.ui.data_stitching_plot.draw()
             QApplication.processEvents()
-
-            o_reduction_progressbar_handler.next_step()
 
         self.parent.big_table_data = self.big_table_data
         o_reduction_progressbar_handler.end()

--- a/src/refred/reduction/normalization_stitching.py
+++ b/src/refred/reduction/normalization_stitching.py
@@ -11,7 +11,7 @@ class ParentHandler(object):
 
     def _calculateSFCE(self, data_type="absolute"):
         """
-        Scaling factor calculation of Ctritical Edge (CE)
+        Scaling factor calculation of Critical Edge (CE)
         """
         _q_min = float(str(self.parent.ui.sf_qmin_value.text()))
         _q_max = float(str(self.parent.ui.sf_qmax_value.text()))
@@ -36,8 +36,10 @@ class ParentHandler(object):
         else:
             _sf = 1
 
-        # Save the SF in first run
-        self.saveSFinLConfig(self.parent.big_table_data[0, 2], _sf, data_type=data_type)
+        # Save the SF in the lowest-q run (first in q-sorted order)
+        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
+        first_q_row = sorted_indices[0] if sorted_indices else 0
+        self.saveSFinLConfig(self.parent.big_table_data[first_q_row, 2], _sf, data_type=data_type)
 
     def saveSFinLConfig(self, lconfig, sf, data_type="absolute"):
         if data_type == "absolute":
@@ -64,7 +66,10 @@ class AbsoluteNormalization(ParentHandler):
         super(AbsoluteNormalization, self).__init__(parent=parent, row_index=row_index, n_runs=n_runs)
 
     def run(self):
-        if self.row_index == 0:
+        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
+        first_q_row = sorted_indices[0] if sorted_indices else 0
+
+        if self.row_index == first_q_row:
             if self.parent.ui.sf_button.isChecked():
                 self.useManuallyDefineSF()
             else:
@@ -74,11 +79,15 @@ class AbsoluteNormalization(ParentHandler):
 
     def useManuallyDefineSF(self):
         _sf = float(str(self.parent.ui.sf_value.text()))
-        data_set = self.getLConfig(0)
+        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
+        first_q_row = sorted_indices[0] if sorted_indices else 0
+        data_set = self.getLConfig(first_q_row)
         data_set.sf_abs_normalization = _sf
 
     def copySFtoOtherAngles(self):
-        ce_lconfig = self.getLConfig(0)
+        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
+        first_q_row = sorted_indices[0] if sorted_indices else 0
+        ce_lconfig = self.getLConfig(first_q_row)
         _sf = ce_lconfig.sf_abs_normalization
         lconfig = self.getLConfig(self.row_index)
         lconfig = self.saveSFinLConfig(lconfig, _sf, data_type="absolute")
@@ -86,7 +95,7 @@ class AbsoluteNormalization(ParentHandler):
 
 class AutomaticStitching(ParentHandler):
     """
-    automatic stiching of the reduced data using the Q range to calculate the CE
+    automatic stitching of the reduced data using the Q range to calculate the CE
     """
 
     def __init__(self, parent=None, row_index=0, n_runs=1):
@@ -96,18 +105,33 @@ class AutomaticStitching(ParentHandler):
         self.use_first_angle_range()
 
     def use_first_angle_range(self):
-        if self.row_index == 0:
+        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
+        first_q_row = sorted_indices[0] if sorted_indices else 0
+
+        if self.row_index == first_q_row:
             self._calculateSFCE(data_type="auto")
         else:
             self._calculateSFOtherAngles()
 
     def _calculateSFOtherAngles(self):
         """
-        Scaling factor calculation of other angles
+        Scaling factor calculation of other angles.
+        Uses q-sorted order to find the correct left (lower-q) neighbor.
         """
-        _row_index = self.row_index
-        left_lconfig = self.getLConfig(_row_index - 1)
-        right_lconfig = self.getLConfig(_row_index)
+        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
+
+        # Find the position of self.row_index in q-sorted order
+        try:
+            q_position = sorted_indices.index(self.row_index)
+        except ValueError:
+            return
+
+        # The left neighbor in q-space is the previous entry in sorted order
+        left_row = sorted_indices[q_position - 1]
+        right_row = self.row_index
+
+        left_lconfig = self.getLConfig(left_row)
+        right_lconfig = self.getLConfig(right_row)
 
         calculate_sf = CalculateSFoverlapRange(left_lconfig, right_lconfig)
         _sf = 1.0 / calculate_sf.getSF()

--- a/src/refred/reduction/normalization_stitching.py
+++ b/src/refred/reduction/normalization_stitching.py
@@ -9,7 +9,7 @@ class ParentHandler(object):
         self.row_index = row_index
         self.n_runs = n_runs
 
-    def _calculateSFCE(self, data_type="absolute"):
+    def _calculateSFCE(self, first_q_row: int, data_type="absolute"):
         """
         Scaling factor calculation of Critical Edge (CE)
         """
@@ -37,9 +37,7 @@ class ParentHandler(object):
             _sf = 1
 
         # Save the SF in the lowest-q run (first in q-sorted order)
-        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
-        first_q_row = sorted_indices[0] if sorted_indices else 0
-        self.saveSFinLConfig(self.parent.big_table_data[first_q_row, 2], _sf, data_type=data_type)
+        self.saveSFinLConfig(self.parent.big_table_data.reduction_config(first_q_row), _sf, data_type=data_type)
 
     def saveSFinLConfig(self, lconfig, sf, data_type="absolute"):
         if data_type == "absolute":
@@ -71,22 +69,18 @@ class AbsoluteNormalization(ParentHandler):
 
         if self.row_index == first_q_row:
             if self.parent.ui.sf_button.isChecked():
-                self.useManuallyDefineSF()
+                self.useManuallyDefineSF(first_q_row)
             else:
-                self._calculateSFCE()
+                self._calculateSFCE(first_q_row)
         else:
-            self.copySFtoOtherAngles()
+            self.copySFtoOtherAngles(first_q_row)
 
-    def useManuallyDefineSF(self):
+    def useManuallyDefineSF(self, first_q_row: int):
         _sf = float(str(self.parent.ui.sf_value.text()))
-        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
-        first_q_row = sorted_indices[0] if sorted_indices else 0
         data_set = self.getLConfig(first_q_row)
         data_set.sf_abs_normalization = _sf
 
-    def copySFtoOtherAngles(self):
-        sorted_indices = self.parent.big_table_data.get_q_sorted_indices()
-        first_q_row = sorted_indices[0] if sorted_indices else 0
+    def copySFtoOtherAngles(self, first_q_row: int):
         ce_lconfig = self.getLConfig(first_q_row)
         _sf = ce_lconfig.sf_abs_normalization
         lconfig = self.getLConfig(self.row_index)
@@ -109,7 +103,7 @@ class AutomaticStitching(ParentHandler):
         first_q_row = sorted_indices[0] if sorted_indices else 0
 
         if self.row_index == first_q_row:
-            self._calculateSFCE(data_type="auto")
+            self._calculateSFCE(first_q_row, data_type="auto")
         else:
             self._calculateSFOtherAngles()
 

--- a/src/refred/reduction/reduced_data_handler.py
+++ b/src/refred/reduction/reduced_data_handler.py
@@ -23,13 +23,15 @@ class ReducedDataHandler(object):
 
     def save_manual_sf(self):
         big_table_data = self.big_table_data
-        for index_row, _lconfig in enumerate(big_table_data[:, 2]):
+        sorted_indices = big_table_data.get_q_sorted_indices()
+        for stitching_row, original_row in enumerate(sorted_indices):
+            _lconfig = big_table_data[original_row, 2]
             if _lconfig is None:
                 break
 
-            sf_manual_value = self.parent.ui.dataStitchingTable.cellWidget(index_row, 1).value()
+            sf_manual_value = self.parent.ui.dataStitchingTable.cellWidget(stitching_row, 1).value()
             _lconfig.sf_manual = sf_manual_value
-            big_table_data[index_row, 2] = _lconfig
+            big_table_data[original_row, 2] = _lconfig
 
         self.big_table_data = big_table_data
         self.parent.big_table_data = big_table_data
@@ -45,7 +47,10 @@ class ReducedDataHandler(object):
         big_table_data = self.big_table_data
         _data = big_table_data[0, 0]
 
-        for index_row, _lconfig in enumerate(big_table_data[:, 2]):
+        sorted_indices = big_table_data.get_q_sorted_indices()
+
+        for color_index, original_row in enumerate(sorted_indices):
+            _lconfig = big_table_data[original_row, 2]
             if _lconfig is None:
                 break
 
@@ -68,7 +73,7 @@ class ReducedDataHandler(object):
             e_axis = o_produce_output.output_e_axis
 
             self.parent.ui.data_stitching_plot.errorbar(
-                _q_axis, y_axis, yerr=e_axis, color=self.get_current_color_plot(index_row)
+                _q_axis, y_axis, yerr=e_axis, color=self.get_current_color_plot(color_index)
             )
 
             if _data.all_plot_axis.is_reduced_plot_stitching_tab_ylog:

--- a/src/refred/reduction/reduced_data_handler.py
+++ b/src/refred/reduction/reduced_data_handler.py
@@ -25,13 +25,13 @@ class ReducedDataHandler(object):
         big_table_data = self.big_table_data
         sorted_indices = big_table_data.get_q_sorted_indices()
         for stitching_row, original_row in enumerate(sorted_indices):
-            _lconfig = big_table_data[original_row, 2]
+            _lconfig = big_table_data.reduction_config(original_row)
             if _lconfig is None:
                 break
 
             sf_manual_value = self.parent.ui.dataStitchingTable.cellWidget(stitching_row, 1).value()
             _lconfig.sf_manual = sf_manual_value
-            big_table_data[original_row, 2] = _lconfig
+            big_table_data.set_reduction_config(original_row, _lconfig)
 
         self.big_table_data = big_table_data
         self.parent.big_table_data = big_table_data
@@ -50,7 +50,7 @@ class ReducedDataHandler(object):
         sorted_indices = big_table_data.get_q_sorted_indices()
 
         for color_index, original_row in enumerate(sorted_indices):
-            _lconfig = big_table_data[original_row, 2]
+            _lconfig = big_table_data.reduction_config(original_row)
             if _lconfig is None:
                 break
 

--- a/src/refred/tabledata.py
+++ b/src/refred/tabledata.py
@@ -152,3 +152,25 @@ class TableData(np.ndarray):
         self[row_begin:row_end, :] = None
         # Move cleared rows to the end by first concatenating non-cleared rows with cleared ones
         self[:] = np.vstack((self[0:row_begin, :], self[row_end:, :], self[row_begin:row_end, :]))
+
+    def get_q_sorted_indices(self):
+        """Return row indices of non-None reduction configs sorted by ascending minimum q-value.
+
+        Returns
+        -------
+        list[int]
+            Row indices sorted by the minimum q-value of each run's q_axis_for_display.
+        """
+        row_q_pairs = []
+        for index_row, _lconfig in enumerate(self[:, 2]):
+            if _lconfig is None:
+                break
+            q_axis = _lconfig.q_axis_for_display
+            if q_axis is not None and len(q_axis) > 0:
+                min_q = np.min(q_axis)
+            else:
+                min_q = float("inf")
+            row_q_pairs.append((index_row, min_q))
+
+        row_q_pairs.sort(key=lambda pair: pair[1])
+        return [pair[0] for pair in row_q_pairs]

--- a/src/refred/tabledata.py
+++ b/src/refred/tabledata.py
@@ -164,7 +164,7 @@ class TableData(np.ndarray):
         row_q_pairs = []
         for index_row, _lconfig in enumerate(self[:, 2]):
             if _lconfig is None:
-                break
+                continue
             q_axis = _lconfig.q_axis_for_display
             if q_axis is not None and len(q_axis) > 0:
                 min_q = np.min(q_axis)

--- a/test/ui/test_data_stitching_table.py
+++ b/test/ui/test_data_stitching_table.py
@@ -1,0 +1,161 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from refred.gui_handling.fill_stitching_table import FillStitchingTable
+from refred.lconfigdataset import LConfigDataset
+from refred.tabledata import TableData
+
+
+def _make_config(q_values, sf_auto=1.0, sf_auto_found_match=True):
+    """Create an LConfigDataset with given q values and scaling factor."""
+    config = LConfigDataset()
+    config.q_axis_for_display = np.array(q_values, dtype=float)
+    config.sf_auto = sf_auto
+    config.sf_abs_normalization = 1.0
+    config.sf_manual = 1.0
+    config.sf_auto_found_match = sf_auto_found_match
+    return config
+
+
+def _make_mock_parent(big_table_data, run_numbers, stitching_type="auto"):
+    """Build a mock parent with the required UI widgets.
+
+    Parameters
+    ----------
+    big_table_data : TableData
+        The populated table data.
+    run_numbers : list[str]
+        Run number strings, one per populated row.
+    stitching_type : str
+        One of "auto", "absolute", "manual".
+    """
+    parent = MagicMock()
+    parent.big_table_data = big_table_data
+
+    # Mock reductionTable items — maps (row, col=1) to run number text
+    def reduction_table_item(row, col):
+        item = MagicMock()
+        if col == 1 and row < len(run_numbers):
+            item.text.return_value = run_numbers[row]
+        else:
+            item.text.return_value = ""
+        return item
+
+    parent.ui.reductionTable.item = reduction_table_item
+
+    # Mock dataStitchingTable with a real dict to capture setItem calls
+    stitching_items = {}
+
+    def set_stitching_item(row, col, item):
+        stitching_items[(row, col)] = item
+
+    parent.ui.dataStitchingTable.setItem = set_stitching_item
+    parent.ui.dataStitchingTable.setCellWidget = MagicMock()
+    parent._stitching_items = stitching_items
+
+    # Mock the stitching type radio buttons
+    parent.ui.absolute_normalization_button.isChecked.return_value = stitching_type == "absolute"
+    parent.ui.auto_stitching_button.isChecked.return_value = stitching_type == "auto"
+    parent.ui.manual_stitching_button.isChecked.return_value = stitching_type == "manual"
+
+    return parent
+
+
+class TestDataStitchingTable:
+    """Tests that the data stitching table fills the rows in the correct order."""
+
+    def test_runs_listed_in_ascending_q_order(self):
+        """Runs stored out of q-order in big_table_data appear sorted in the stitching table."""
+        table = TableData(5)
+        # Row 0: highest q (run 333)
+        table.set_reduction_config(0, _make_config([0.07, 0.08, 0.09]))
+        # Row 1: lowest q (run 111)
+        table.set_reduction_config(1, _make_config([0.01, 0.02, 0.03]))
+        # Row 2: middle q (run 222)
+        table.set_reduction_config(2, _make_config([0.04, 0.05, 0.06]))
+
+        run_numbers = ["333", "111", "222"]
+        parent = _make_mock_parent(table, run_numbers, stitching_type="auto")
+
+        sorted_indices = table.get_q_sorted_indices()
+        assert sorted_indices == [1, 2, 0]
+
+        o_fill = FillStitchingTable(parent=parent)
+        for stitching_row, original_row in enumerate(sorted_indices):
+            o_fill.fillRow(row_index=original_row, stitching_row=stitching_row)
+
+        items = parent._stitching_items
+        # Stitching table row 0 should have run "111" (lowest q)
+        assert items[(0, 0)].text() == "111"
+        # Stitching table row 1 should have run "222" (middle q)
+        assert items[(1, 0)].text() == "222"
+        # Stitching table row 2 should have run "333" (highest q)
+        assert items[(2, 0)].text() == "333"
+
+    def test_already_sorted_rows_preserve_order(self):
+        """When big_table_data rows are already in q order, stitching table matches."""
+        table = TableData(5)
+        table.set_reduction_config(0, _make_config([0.01, 0.02]))
+        table.set_reduction_config(1, _make_config([0.03, 0.04]))
+
+        run_numbers = ["100", "200"]
+        parent = _make_mock_parent(table, run_numbers, stitching_type="auto")
+
+        sorted_indices = table.get_q_sorted_indices()
+        assert sorted_indices == [0, 1]
+
+        o_fill = FillStitchingTable(parent=parent)
+        for stitching_row, original_row in enumerate(sorted_indices):
+            o_fill.fillRow(row_index=original_row, stitching_row=stitching_row)
+
+        items = parent._stitching_items
+        assert items[(0, 0)].text() == "100"
+        assert items[(1, 0)].text() == "200"
+
+    def test_single_row(self):
+        """A single row should appear at stitching row 0."""
+        table = TableData(5)
+        table.set_reduction_config(0, _make_config([0.05, 0.06]))
+
+        run_numbers = ["999"]
+        parent = _make_mock_parent(table, run_numbers, stitching_type="absolute")
+
+        sorted_indices = table.get_q_sorted_indices()
+        assert sorted_indices == [0]
+
+        o_fill = FillStitchingTable(parent=parent)
+        for stitching_row, original_row in enumerate(sorted_indices):
+            o_fill.fillRow(row_index=original_row, stitching_row=stitching_row)
+
+        items = parent._stitching_items
+        assert items[(0, 0)].text() == "999"
+
+    def test_four_runs_scrambled(self):
+        """Four runs in scrambled q-order should appear sorted in the stitching table."""
+        table = TableData(6)
+        table.set_reduction_config(0, _make_config([0.05, 0.06]))  # 3rd
+        table.set_reduction_config(1, _make_config([0.09, 0.10]))  # 4th
+        table.set_reduction_config(2, _make_config([0.01, 0.02]))  # 1st
+        table.set_reduction_config(3, _make_config([0.03, 0.04]))  # 2nd
+
+        run_numbers = ["AAA", "BBB", "CCC", "DDD"]
+        parent = _make_mock_parent(table, run_numbers, stitching_type="auto")
+
+        sorted_indices = table.get_q_sorted_indices()
+        assert sorted_indices == [2, 3, 0, 1]
+
+        o_fill = FillStitchingTable(parent=parent)
+        for stitching_row, original_row in enumerate(sorted_indices):
+            o_fill.fillRow(row_index=original_row, stitching_row=stitching_row)
+
+        items = parent._stitching_items
+        assert items[(0, 0)].text() == "CCC"
+        assert items[(1, 0)].text() == "DDD"
+        assert items[(2, 0)].text() == "AAA"
+        assert items[(3, 0)].text() == "BBB"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/unit/refred/test_tabledata.py
+++ b/test/unit/refred/test_tabledata.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from refred.calculations.lr_data import LRData
@@ -77,6 +78,49 @@ class TestTableData:
         for row_index in range(row_begin, row_end):
             del counters[row_begin]
         assert new_counters == counters
+
+    def _make_config_with_q(self, q_values):
+        """Helper to create an LConfigDataset with the given q_axis_for_display."""
+        config = LConfigDataset()
+        config.q_axis_for_display = np.array(q_values, dtype=float)
+        return config
+
+    def test_get_q_sorted_indices_already_sorted(self):
+        """Rows already in ascending q order should be returned as-is."""
+        self.table.set_reduction_config(0, self._make_config_with_q([0.01, 0.02, 0.03]))
+        self.table.set_reduction_config(1, self._make_config_with_q([0.04, 0.05, 0.06]))
+        self.table.set_reduction_config(2, self._make_config_with_q([0.07, 0.08, 0.09]))
+        assert self.table.get_q_sorted_indices() == [0, 1, 2]
+
+    def test_get_q_sorted_indices_reverse_order(self):
+        """Rows in descending q order should be reversed."""
+        self.table.set_reduction_config(0, self._make_config_with_q([0.07, 0.08, 0.09]))
+        self.table.set_reduction_config(1, self._make_config_with_q([0.04, 0.05, 0.06]))
+        self.table.set_reduction_config(2, self._make_config_with_q([0.01, 0.02, 0.03]))
+        assert self.table.get_q_sorted_indices() == [2, 1, 0]
+
+    def test_get_q_sorted_indices_scrambled(self):
+        """Rows in arbitrary order should be sorted by ascending min(q)."""
+        self.table.set_reduction_config(0, self._make_config_with_q([0.04, 0.05, 0.06]))
+        self.table.set_reduction_config(1, self._make_config_with_q([0.01, 0.02, 0.03]))
+        self.table.set_reduction_config(2, self._make_config_with_q([0.07, 0.08, 0.09]))
+        assert self.table.get_q_sorted_indices() == [1, 0, 2]
+
+    def test_get_q_sorted_indices_single_row(self):
+        """A single populated row should return a single-element list."""
+        self.table.set_reduction_config(0, self._make_config_with_q([0.05, 0.06]))
+        assert self.table.get_q_sorted_indices() == [0]
+
+    def test_get_q_sorted_indices_empty_table(self):
+        """A table with no reduction configs should return an empty list."""
+        assert self.table.get_q_sorted_indices() == []
+
+    def test_get_q_sorted_indices_overlapping_q_ranges(self):
+        """Rows with overlapping q ranges should sort by their minimum q value."""
+        self.table.set_reduction_config(0, self._make_config_with_q([0.03, 0.05, 0.07]))
+        self.table.set_reduction_config(1, self._make_config_with_q([0.01, 0.04, 0.06]))
+        self.table.set_reduction_config(2, self._make_config_with_q([0.02, 0.03, 0.08]))
+        assert self.table.get_q_sorted_indices() == [1, 2, 0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:
A defect was found that if auto stitching was applied to runs with q values not in order. This PR modifies the data stitching tab to sort the runs by q values, allowing auto stitching to execute properly

Check all that apply:

- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)

**References:**

- Links to IBM EWM items: [13931: [RefRed] Reorder data and normalization runs by ascending Q-value](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/13931)
- Links to related issues or pull requests:

## :warning:  Manual test for the reviewer

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
