### PR TITLE
Save and Load Stitching from Template

### DIFF
--- a/src/refred/configuration/export_xml_config.py
+++ b/src/refred/configuration/export_xml_config.py
@@ -206,22 +206,26 @@ class ExportXMLConfig(object):
 
             # stitching configuration
             str_array.append("   <stitching_type>" + xml_stitching_type + "</stitching_type>\n")
-            str_array.append("   <scale_factor_qmin>" + str(self.parent.ui.sf_qmin_value.text()) + "</scale_factor_qmin>\n")
-            str_array.append("   <scale_factor_qmax>" + str(self.parent.ui.sf_qmax_value.text()) + "</scale_factor_qmax>\n")
+            str_array.append(
+                "   <scale_factor_qmin>" + str(self.parent.ui.sf_qmin_value.text()) + "</scale_factor_qmin>\n"
+            )
+            str_array.append(
+                "   <scale_factor_qmax>" + str(self.parent.ui.sf_qmax_value.text()) + "</scale_factor_qmax>\n"
+            )
             str_array.append("   <normalize_first_angle>True</normalize_first_angle>\n")
 
             # Write the per-row reflectivity stitching scale factor
             _lconfig = _big_table_data[row, 2]
             if _lconfig is not None:
-                sf = _lconfig.sf_auto if gui_stitching_type == "auto" else (
-                    _lconfig.sf_abs_normalization if gui_stitching_type == "absolute" else _lconfig.sf_manual
+                sf = (
+                    _lconfig.sf_auto
+                    if gui_stitching_type == "auto"
+                    else (_lconfig.sf_abs_normalization if gui_stitching_type == "absolute" else _lconfig.sf_manual)
                 )
             else:
                 sf = 1.0
             str_array.append(
-                "   <stitching_reflectivity_scale_factor>"
-                + str(sf)
-                + "</stitching_reflectivity_scale_factor>\n"
+                "   <stitching_reflectivity_scale_factor>" + str(sf) + "</stitching_reflectivity_scale_factor>\n"
             )
 
             str_array.append("  </RefLData>\n")

--- a/src/refred/configuration/export_xml_config.py
+++ b/src/refred/configuration/export_xml_config.py
@@ -212,7 +212,8 @@ class ExportXMLConfig(object):
             str_array.append(
                 "   <scale_factor_qmax>" + str(self.parent.ui.sf_qmax_value.text()) + "</scale_factor_qmax>\n"
             )
-            str_array.append("   <normalize_first_angle>True</normalize_first_angle>\n")
+            normalize_first_angle = self.parent.ui.normalize_first_angle_checkbox.isChecked()
+            str_array.append(f"   <normalize_first_angle>{normalize_first_angle}</normalize_first_angle>\n")
 
             # Write the per-row reflectivity stitching scale factor
             _lconfig = _big_table_data[row, 2]

--- a/src/refred/configuration/export_xml_config.py
+++ b/src/refred/configuration/export_xml_config.py
@@ -8,12 +8,20 @@ import mantid
 
 import refred
 from refred.calculations.lr_data import LRData
+from refred.gui_handling.gui_utility import GuiUtility
 from refred.reduction.global_reduction_settings_handler import (
     GlobalReductionSettingsHandler,
 )
 
 if TYPE_CHECKING:
     from refred.main import MainGui
+
+# Map RefRed stitching values to lrred/xml types
+_STITCHING_TYPE_TO_XML = {
+    "absolute": "AbsoluteNormalization",
+    "auto": "AutomaticAverage",
+    "manual": "None",
+}
 
 
 class ExportXMLConfig(object):
@@ -40,6 +48,11 @@ class ExportXMLConfig(object):
         _big_table_data = self.parent.big_table_data
         nbr_row = self.parent.REDUCTIONTABLE_MAX_ROWCOUNT
         o_general_settings = GlobalReductionSettingsHandler(parent=self.parent)
+
+        # Get the active stitching type and map to XML value
+        o_gui = GuiUtility(parent=self.parent)
+        gui_stitching_type = o_gui.getStitchingType()
+        xml_stitching_type = _STITCHING_TYPE_TO_XML.get(gui_stitching_type, "None")
 
         for row in range(nbr_row):
             _data: LRData = _big_table_data[row, 0]
@@ -190,6 +203,26 @@ class ExportXMLConfig(object):
             str_array.append(o_general_settings.instrument_settings.to_xml(indent="   "))
 
             str_array.append("   <const_q>" + str(const_q) + "</const_q>\n")
+
+            # stitching configuration
+            str_array.append("   <stitching_type>" + xml_stitching_type + "</stitching_type>\n")
+            str_array.append("   <scale_factor_qmin>" + str(self.parent.ui.sf_qmin_value.text()) + "</scale_factor_qmin>\n")
+            str_array.append("   <scale_factor_qmax>" + str(self.parent.ui.sf_qmax_value.text()) + "</scale_factor_qmax>\n")
+            str_array.append("   <normalize_first_angle>True</normalize_first_angle>\n")
+
+            # Write the per-row reflectivity stitching scale factor
+            _lconfig = _big_table_data[row, 2]
+            if _lconfig is not None:
+                sf = _lconfig.sf_auto if gui_stitching_type == "auto" else (
+                    _lconfig.sf_abs_normalization if gui_stitching_type == "absolute" else _lconfig.sf_manual
+                )
+            else:
+                sf = 1.0
+            str_array.append(
+                "   <stitching_reflectivity_scale_factor>"
+                + str(sf)
+                + "</stitching_reflectivity_scale_factor>\n"
+            )
 
             str_array.append("  </RefLData>\n")
 

--- a/src/refred/configuration/loading_configuration.py
+++ b/src/refred/configuration/loading_configuration.py
@@ -15,10 +15,10 @@ from refred.configuration.populate_reduction_table_from_lconfigdataset import (
 from refred.gui_handling.first_angle_range_gui_handler import (
     NormalizationOrStitchingButtonStatus,
 )
+from refred.gui_handling.gui_utility import GuiUtility
 from refred.gui_handling.scaling_factor_widgets_handler import (
     ScalingFactorWidgetsHandler,
 )
-from refred.gui_handling.gui_utility import GuiUtility
 from refred.lconfigdataset import LConfigDataset
 from refred.plot.clear_plots import ClearPlots
 from refred.reduction_table_handling.reduction_table_handler import ReductionTableHandler

--- a/src/refred/configuration/loading_configuration.py
+++ b/src/refred/configuration/loading_configuration.py
@@ -12,7 +12,9 @@ from refred.configuration.load_reduction_table_from_lconfigdataset import (
 from refred.configuration.populate_reduction_table_from_lconfigdataset import (
     PopulateReductionTableFromLConfigDataSet as PopulateReductionTable,
 )
-from refred.gui_handling.gui_utility import GuiUtility
+from refred.gui_handling.first_angle_range_gui_handler import (
+    NormalizationOrStitchingButtonStatus,
+)
 from refred.gui_handling.scaling_factor_widgets_handler import (
     ScalingFactorWidgetsHandler,
 )
@@ -193,12 +195,17 @@ class LoadingConfiguration(object):
         stitching_type_str = self.getNodeValue(node_0, "stitching_type", default="None")
 
         # Map the lr_reduction StitchingType value back to the RefRed GUI radio button
+        # and sync all dependent widget states (including normalize_first_angle_checkbox)
+        norm_or_stitching = NormalizationOrStitchingButtonStatus(parent=self.parent)
         if stitching_type_str == "AbsoluteNormalization":
             self.parent.ui.absolute_normalization_button.setChecked(True)
+            norm_or_stitching.setWidget(activated_button=0)
         elif stitching_type_str == "AutomaticAverage":
             self.parent.ui.auto_stitching_button.setChecked(True)
+            norm_or_stitching.setWidget(activated_button=1)
         elif stitching_type_str == "None":
             self.parent.ui.manual_stitching_button.setChecked(True)
+            norm_or_stitching.setWidget(activated_button=2)
 
     def getMetadataObject(self, node) -> LConfigDataset:
         r"""Populate an instance of type LConfigDataset using the information contained in one of the

--- a/src/refred/configuration/loading_configuration.py
+++ b/src/refred/configuration/loading_configuration.py
@@ -190,6 +190,17 @@ class LoadingConfiguration(object):
             self.parent.instrument_settings.apply_instrument_settings
         )
 
+        stitching_type_str = self.getNodeValue(node_0, "stitching_type", default="None")
+
+        # Map the lr_reduction StitchingType value back to the RefRed GUI radio button
+        if stitching_type_str == "AbsoluteNormalization":
+            self.parent.ui.absolute_normalization_button.setChecked(True)
+        elif stitching_type_str == "AutomaticAverage":
+            self.parent.ui.auto_stitching_button.setChecked(True)
+        elif stitching_type_str == "None":
+            self.parent.ui.manual_stitching_button.setChecked(True)
+
+
     def getMetadataObject(self, node) -> LConfigDataset:
         r"""Populate an instance of type LConfigDataset using the information contained in one of the
         'RefLData    XML blocks within a configuration file."""
@@ -290,6 +301,17 @@ class LoadingConfiguration(object):
         except:
             _norm_full_file_name = [""]
         iMetadata.norm_full_file_name = _norm_full_file_name
+
+        stitching_refl_sf = float(self.getNodeValue(node, "stitching_reflectivity_scale_factor", default="1.0"))
+
+        # Map the scale factor value to the corresponding active stitching type
+        stitching_type_str = self.getNodeValue(node, "stitching_type", default="None")
+        if stitching_type_str == "AbsoluteNormalization":
+            iMetadata.sf_abs_normalization = stitching_refl_sf
+        elif stitching_type_str == "AutomaticAverage":
+            iMetadata.sf_auto = stitching_refl_sf
+        else:
+            iMetadata.sf_manual = stitching_refl_sf
 
         return iMetadata
 

--- a/src/refred/configuration/loading_configuration.py
+++ b/src/refred/configuration/loading_configuration.py
@@ -200,7 +200,6 @@ class LoadingConfiguration(object):
         elif stitching_type_str == "None":
             self.parent.ui.manual_stitching_button.setChecked(True)
 
-
     def getMetadataObject(self, node) -> LConfigDataset:
         r"""Populate an instance of type LConfigDataset using the information contained in one of the
         'RefLData    XML blocks within a configuration file."""

--- a/src/refred/configuration/loading_configuration.py
+++ b/src/refred/configuration/loading_configuration.py
@@ -18,6 +18,7 @@ from refred.gui_handling.first_angle_range_gui_handler import (
 from refred.gui_handling.scaling_factor_widgets_handler import (
     ScalingFactorWidgetsHandler,
 )
+from refred.gui_handling.gui_utility import GuiUtility
 from refred.lconfigdataset import LConfigDataset
 from refred.plot.clear_plots import ClearPlots
 from refred.reduction_table_handling.reduction_table_handler import ReductionTableHandler

--- a/src/refred/gui_handling/first_angle_range_gui_handler.py
+++ b/src/refred/gui_handling/first_angle_range_gui_handler.py
@@ -46,6 +46,7 @@ class NormalizationOrStitchingButtonStatus(ParentGuiHandler):
         self.handleWidgets()
 
     def handleWidgets(self):
+        self.parent.ui.normalize_first_angle_checkbox.setEnabled(self.is_auto_stitching)
         if self.is_manual_stitching:
             self.parent.ui.sf_first_angle_range_group.setEnabled(False)
             return

--- a/src/refred/interfaces/refred_main_interface.ui
+++ b/src/refred/interfaces/refred_main_interface.ui
@@ -4902,6 +4902,16 @@
                        </property>
                       </widget>
                      </item>
+                     <item>
+                      <widget class="QCheckBox" name="normalize_first_angle_checkbox">
+                       <property name="text">
+                        <string>Normalize first angle</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
                     </layout>
                    </item>
                   </layout>

--- a/src/refred/interfaces/refred_main_interface.ui
+++ b/src/refred/interfaces/refred_main_interface.ui
@@ -4904,6 +4904,9 @@
                      </item>
                      <item>
                       <widget class="QCheckBox" name="normalize_first_angle_checkbox">
+                       <property name="enabled">
+                        <bool>false</bool>
+                       </property>
                        <property name="text">
                         <string>Normalize first angle</string>
                        </property>

--- a/src/refred/lconfigdataset.py
+++ b/src/refred/lconfigdataset.py
@@ -54,9 +54,9 @@ class LConfigDataset(object):
     wks_scaled = None
     meta_data = None
 
-    sf_auto = 1  # auto scaling calculated by program (auto stitching)
-    sf_manual = 1  # manual scaling (manual stitching)
-    sf_abs_normalization = 1  # absolute normalization
+    sf_auto = 1.0  # auto scaling calculated by program (auto stitching)
+    sf_manual = 1.0  # manual scaling (manual stitching)
+    sf_abs_normalization = 1.0  # absolute normalization
 
     sf_auto_found_match = False
     sf = 1  # scaling factor apply to data (will be either the auto, manual or 1)

--- a/src/refred/reduction/global_reduction_settings_handler.py
+++ b/src/refred/reduction/global_reduction_settings_handler.py
@@ -1,4 +1,12 @@
 from refred.configuration.global_settings import GlobalSettings
+from refred.gui_handling.gui_utility import GuiUtility
+
+# Map RefRed stitching values to lrred/xml types
+_STITCHING_TYPE_TO_XML = {
+    "absolute": "AbsoluteNormalization",
+    "auto": "AutomaticAverage",
+    "manual": "None",
+}
 
 
 class GlobalReductionSettingsHandler(object):
@@ -23,6 +31,9 @@ class GlobalReductionSettingsHandler(object):
 
     def retrieve_settings(self):
         r"""Retrieve the values of all the global settings from the GUI or from GlobalSettings instances"""
+        # Get the active stitching type and map to XML value
+        o_gui = GuiUtility(parent=self.parent)
+        gui_stitching_type = o_gui.getStitchingType()
         self.settings.update(
             {
                 "incident_medium_selected": str(self.parent.ui.selectIncidentMediumList.currentText()).strip(),
@@ -37,6 +48,7 @@ class GlobalReductionSettingsHandler(object):
                 "apply_normalization": self.parent.ui.useNormalizationFlag.isChecked(),
                 "dead_time": self.parent.deadtime_settings,  # an instance of `DeadTimeSettingsModel`
                 "instrument_settings": self.parent.instrument_settings,  # an instance of `InstrumentSettings`
+                "stitching_type": _STITCHING_TYPE_TO_XML.get(gui_stitching_type, "None"),
             }
         )
 

--- a/test/unit/refred/configuration/test_export_xml_config.py
+++ b/test/unit/refred/configuration/test_export_xml_config.py
@@ -6,6 +6,15 @@ import pytest
 from refred.configuration.export_xml_config import ExportXMLConfig
 
 
+def _make_config_with_mock_gui(stitching_type="manual"):
+    """Helper: return an ExportXMLConfig whose GuiUtility returns the given stitching_type."""
+    parent = MagicMock()
+    config = ExportXMLConfig(parent)
+    # Patch GuiUtility used inside main_part
+    config._gui_stitching_type = stitching_type
+    return config
+
+
 class TestExportXMLConfig:
     @patch("refred.configuration.export_xml_config.refred")
     @patch("refred.configuration.export_xml_config.mantid")
@@ -20,10 +29,82 @@ class TestExportXMLConfig:
         assert "<mantid_version>1.0.0</mantid_version>" in header
         assert "<generator>refred-2.0.0</generator>" in header
 
-    def test_main_part(self):
+    @patch("refred.configuration.export_xml_config.GuiUtility")
+    def test_main_part(self, mock_gui_utility):
+        mock_gui_utility.return_value.getStitchingType.return_value = "manual"
         config = ExportXMLConfig(MagicMock())
         config.main_part()
-        assert len(config.str_array) == 56
+        assert len(config.str_array) == 61
+
+    @pytest.mark.parametrize(
+        "stitching_type, expected_xml_value",
+        [
+            ("absolute", "AbsoluteNormalization"),
+            ("auto", "AutomaticAverage"),
+            ("manual", "None"),
+        ],
+    )
+    @patch("refred.configuration.export_xml_config.GuiUtility")
+    def test_main_part_stitching_type_tag(self, mock_gui_utility, stitching_type, expected_xml_value):
+        mock_gui_utility.return_value.getStitchingType.return_value = stitching_type
+        parent = MagicMock()
+        parent.deadtime_settings.to_xml.return_value = ""
+        parent.instrument_settings.to_xml.return_value = ""
+        config = ExportXMLConfig(parent)
+        config.main_part()
+        xml = "".join(s for s in config.str_array if isinstance(s, str))
+        assert f"<stitching_type>{expected_xml_value}</stitching_type>" in xml
+
+    @pytest.mark.parametrize(
+        "stitching_type, sf_field, sf_value",
+        [
+            ("absolute", "sf_abs_normalization", 2.5),
+            ("auto", "sf_auto", 3.14),
+            ("manual", "sf_manual", 0.75),
+        ],
+    )
+    @patch("refred.configuration.export_xml_config.GuiUtility")
+    def test_main_part_stitching_sf_from_lconfig(self, mock_gui_utility, stitching_type, sf_field, sf_value):
+        """The per-row scale factor tag reflects the correct sf_* field on lconfig."""
+        mock_gui_utility.return_value.getStitchingType.return_value = stitching_type
+
+        parent = MagicMock()
+        parent.deadtime_settings.to_xml.return_value = ""
+        parent.instrument_settings.to_xml.return_value = ""
+
+        lconfig = MagicMock()
+        setattr(lconfig, sf_field, sf_value)
+
+        def _getitem(key):
+            row, col = key
+            return lconfig if col == 2 else MagicMock()
+
+        parent.big_table_data.__getitem__.side_effect = _getitem
+
+        config = ExportXMLConfig(parent)
+        config.main_part()
+        xml = "".join(s for s in config.str_array if isinstance(s, str))
+        assert f"<stitching_reflectivity_scale_factor>{sf_value}</stitching_reflectivity_scale_factor>" in xml
+
+    @patch("refred.configuration.export_xml_config.GuiUtility")
+    def test_main_part_stitching_sf_fallback_when_lconfig_none(self, mock_gui_utility):
+        """When big_table_data[row, 2] is None the scale factor falls back to 1.0."""
+        mock_gui_utility.return_value.getStitchingType.return_value = "manual"
+
+        parent = MagicMock()
+        parent.deadtime_settings.to_xml.return_value = ""
+        parent.instrument_settings.to_xml.return_value = ""
+
+        def _getitem(key):
+            row, col = key
+            return None if col == 2 else MagicMock()
+
+        parent.big_table_data.__getitem__.side_effect = _getitem
+
+        config = ExportXMLConfig(parent)
+        config.main_part()
+        xml = "".join(s for s in config.str_array if isinstance(s, str))
+        assert "<stitching_reflectivity_scale_factor>1.0</stitching_reflectivity_scale_factor>" in xml
 
 
 if __name__ == "__main__":

--- a/test/unit/refred/configuration/test_export_xml_config.py
+++ b/test/unit/refred/configuration/test_export_xml_config.py
@@ -32,9 +32,23 @@ class TestExportXMLConfig:
     @patch("refred.configuration.export_xml_config.GuiUtility")
     def test_main_part(self, mock_gui_utility):
         mock_gui_utility.return_value.getStitchingType.return_value = "manual"
-        config = ExportXMLConfig(MagicMock())
+        parent = MagicMock()
+        parent.ui.normalize_first_angle_checkbox.isChecked.return_value = True
+        config = ExportXMLConfig(parent)
         config.main_part()
         assert len(config.str_array) == 61
+
+    @pytest.mark.parametrize("checked, expected_xml_value", [(True, "True"), (False, "False")])
+    @patch("refred.configuration.export_xml_config.GuiUtility")
+    def test_main_part_normalize_first_angle(self, mock_gui_utility, checked, expected_xml_value):
+        """normalize_first_angle XML tag reflects the checkbox state."""
+        mock_gui_utility.return_value.getStitchingType.return_value = "manual"
+        parent = MagicMock()
+        parent.ui.normalize_first_angle_checkbox.isChecked.return_value = checked
+        config = ExportXMLConfig(parent)
+        config.main_part()
+        xml = "".join(s for s in config.str_array if isinstance(s, str))
+        assert f"<normalize_first_angle>{expected_xml_value}</normalize_first_angle>" in xml
 
     @pytest.mark.parametrize(
         "stitching_type, expected_xml_value",

--- a/test/unit/refred/configuration/test_loading_configuration.py
+++ b/test/unit/refred/configuration/test_loading_configuration.py
@@ -84,8 +84,8 @@ class TestLoadingConfiguration(object):
             "scaling_factor_flag": 6.006,
         }
 
-        def side_effect(node, arg):
-            return values[arg]
+        def side_effect(node, arg, default=""):
+            return values.get(arg, default)
 
         loadingConfiguration.getNodeValue = mock.Mock()
         loadingConfiguration.getNodeValue.side_effect = side_effect
@@ -190,6 +190,114 @@ class TestLoadingConfiguration(object):
         assert config.data_back[1] == values["back_roi1_to"]
         assert config.data_low_res == [values["x_min_pixel"], values["x_max_pixel"]]
         assert config.const_q == values["const_q"]
+
+    # ------------------------------------------------------------------
+    # Stitching type → radio button mapping
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "xml_value, button_attr",
+        [
+            ("AbsoluteNormalization", "absolute_normalization_button"),
+            ("AutomaticAverage", "auto_stitching_button"),
+            ("None", "manual_stitching_button"),
+        ],
+    )
+    def test_populate_main_gui_general_settings_stitching_radio(self, xml_value, button_attr):
+        """The correct radio button is set when loading stitching_type from XML."""
+        loader = self.test_init()
+
+        loader.parent.ui.selectIncidentMediumList.count.return_value = 0
+
+        # Provide numeric defaults for fields that populate_main_gui_general_settings casts to int/float
+        _numeric_defaults = {
+            "incident_medium_index_selected": "0",
+            "q_step": "0.02",
+            "q_min": "0.005",
+            "angle_offset": "0.0",
+            "angle_offset_error": "0.0",
+            "scaling_factor_flag": "False",
+            "scaling_factor_file": "",
+            "norm_flag": "False",
+        }
+
+        def node_value(node, flag, default=""):
+            if flag == "stitching_type":
+                return xml_value
+            return _numeric_defaults.get(flag, default)
+
+        loader.getNodeValue = mock.Mock(side_effect=node_value)
+        loader.dom = mock.Mock()
+        node_0 = mock.Mock()
+        loader.dom.getElementsByTagName.return_value = [node_0]
+        loader.parent.gui_metadata = mock.MagicMock()
+        loader.parent.deadtime_settings = mock.MagicMock()
+        loader.parent.instrument_settings = mock.MagicMock()
+
+        loader.populate_main_gui_general_settings()
+
+        getattr(loader.parent.ui, button_attr).setChecked.assert_called_once_with(True)
+
+    # ------------------------------------------------------------------
+    # Stitching scale factor → LConfigDataset field mapping
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "xml_stitching_type, sf_field",
+        [
+            ("AbsoluteNormalization", "sf_abs_normalization"),
+            ("AutomaticAverage", "sf_auto"),
+            ("None", "sf_manual"),
+        ],
+    )
+    def test_getMetadataObject_stitching_sf(self, xml_stitching_type, sf_field):
+        """The stitching_reflectivity_scale_factor is stored in the correct LConfigDataset field."""
+        loader = self.test_init()
+        node_mock = mock.Mock()
+
+        sf_value = 2.718
+
+        base_values = {
+            "from_peak_pixels": 1,
+            "to_peak_pixels": 2,
+            "back_roi1_from": 3,
+            "back_roi1_to": 4,
+            "x_min_pixel": 5,
+            "x_max_pixel": 6,
+            "background_flag": False,
+            "x_range_flag": False,
+            "from_tof_range": 0,
+            "to_tof_range": 1,
+            "from_q_range": 0,
+            "to_q_range": 1,
+            "from_lambda_range": 0,
+            "to_lambda_range": 1,
+            "data_sets": "",
+            "tof_range_flag": False,
+            "norm_from_peak_pixels": 0,
+            "norm_to_peak_pixels": 1,
+            "norm_from_back_pixels": 0,
+            "norm_to_back_pixels": 1,
+            "norm_dataset": "",
+            "norm_x_min": 0,
+            "norm_x_max": 1,
+            "norm_background_flag": False,
+            "norm_x_range_flag": False,
+            "data_full_file_name": "",
+            "norm_full_file_name": "",
+            "const_q": False,
+            "stitching_type": xml_stitching_type,
+            "stitching_reflectivity_scale_factor": str(sf_value),
+        }
+
+        def side_effect(_, arg, default=""):
+            return base_values.get(arg, default)
+
+        loader.getNodeValue = mock.Mock(side_effect=side_effect)
+
+        config = loader.getMetadataObject(node_mock)
+
+        assert getattr(config, sf_field) == pytest.approx(sf_value)
 
 
 if __name__ == "__main__":

--- a/test/unit/refred/configuration/test_loading_configuration.py
+++ b/test/unit/refred/configuration/test_loading_configuration.py
@@ -238,6 +238,53 @@ class TestLoadingConfiguration(object):
 
         getattr(loader.parent.ui, button_attr).setChecked.assert_called_once_with(True)
 
+    @pytest.mark.parametrize(
+        "xml_value, button_attr, activated_button",
+        [
+            ("AbsoluteNormalization", "absolute_normalization_button", 0),
+            ("AutomaticAverage", "auto_stitching_button", 1),
+            ("None", "manual_stitching_button", 2),
+        ],
+    )
+    @mock.patch("refred.configuration.loading_configuration.NormalizationOrStitchingButtonStatus")
+    def test_populate_main_gui_general_settings_stitching_sets_widget(
+        self, MockNormStatus, xml_value, button_attr, activated_button
+    ):
+        """Loading a stitching type calls NormalizationOrStitchingButtonStatus.setWidget
+        so that normalize_first_angle_checkbox (and other dependent widgets) are
+        enabled/disabled correctly."""
+        loader = self.test_init()
+
+        loader.parent.ui.selectIncidentMediumList.count.return_value = 0
+
+        _numeric_defaults = {
+            "incident_medium_index_selected": "0",
+            "q_step": "0.02",
+            "q_min": "0.005",
+            "angle_offset": "0.0",
+            "angle_offset_error": "0.0",
+            "scaling_factor_flag": "False",
+            "scaling_factor_file": "",
+            "norm_flag": "False",
+        }
+
+        def node_value(node, flag, default=""):
+            if flag == "stitching_type":
+                return xml_value
+            return _numeric_defaults.get(flag, default)
+
+        loader.getNodeValue = mock.Mock(side_effect=node_value)
+        loader.dom = mock.Mock()
+        node_0 = mock.Mock()
+        loader.dom.getElementsByTagName.return_value = [node_0]
+        loader.parent.gui_metadata = mock.MagicMock()
+        loader.parent.deadtime_settings = mock.MagicMock()
+        loader.parent.instrument_settings = mock.MagicMock()
+
+        loader.populate_main_gui_general_settings()
+
+        MockNormStatus.return_value.setWidget.assert_called_once_with(activated_button=activated_button)
+
     # ------------------------------------------------------------------
     # Stitching scale factor → LConfigDataset field mapping
     # ------------------------------------------------------------------

--- a/test/unit/refred/gui_handling/test_normalization_or_stitching_button_status.py
+++ b/test/unit/refred/gui_handling/test_normalization_or_stitching_button_status.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from refred.gui_handling.first_angle_range_gui_handler import NormalizationOrStitchingButtonStatus
 
@@ -8,7 +9,7 @@ from refred.gui_handling.first_angle_range_gui_handler import NormalizationOrSti
     "activated_button, expected_enabled",
     [
         (0, False),  # Absolute Normalization → checkbox disabled
-        (1, True),   # Auto. Stitching       → checkbox enabled
+        (1, True),  # Auto. Stitching       → checkbox enabled
         (2, False),  # Manual Stitching      → checkbox disabled
     ],
 )

--- a/test/unit/refred/gui_handling/test_normalization_or_stitching_button_status.py
+++ b/test/unit/refred/gui_handling/test_normalization_or_stitching_button_status.py
@@ -1,0 +1,20 @@
+import pytest
+from unittest.mock import MagicMock
+
+from refred.gui_handling.first_angle_range_gui_handler import NormalizationOrStitchingButtonStatus
+
+
+@pytest.mark.parametrize(
+    "activated_button, expected_enabled",
+    [
+        (0, False),  # Absolute Normalization → checkbox disabled
+        (1, True),   # Auto. Stitching       → checkbox enabled
+        (2, False),  # Manual Stitching      → checkbox disabled
+    ],
+)
+def test_normalize_first_angle_checkbox_enabled_state(activated_button, expected_enabled):
+    """normalize_first_angle_checkbox is enabled only when Auto. Stitching is selected."""
+    parent = MagicMock()
+    handler = NormalizationOrStitchingButtonStatus(parent=parent)
+    handler.setWidget(activated_button=activated_button)
+    parent.ui.normalize_first_angle_checkbox.setEnabled.assert_called_with(expected_enabled)

--- a/test/unit/refred/reduction/test_global_reduction_settings_handler.py
+++ b/test/unit/refred/reduction/test_global_reduction_settings_handler.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from refred.reduction.global_reduction_settings_handler import GlobalReductionSettingsHandler
+
+
+class TestGlobalReductionSettingsHandler:
+    @pytest.mark.parametrize(
+        "gui_stitching_type, expected_xml_value",
+        [
+            ("absolute", "AbsoluteNormalization"),
+            ("auto", "AutomaticAverage"),
+            ("manual", "None"),
+        ],
+    )
+    @patch("refred.reduction.global_reduction_settings_handler.GuiUtility")
+    def test_stitching_type_in_settings(self, mock_gui_utility_cls, gui_stitching_type, expected_xml_value):
+        """stitching_type is present in settings and mapped to the correct XML value."""
+        mock_gui_utility_cls.return_value.getStitchingType.return_value = gui_stitching_type
+
+        parent = MagicMock()
+        handler = GlobalReductionSettingsHandler(parent=parent)
+
+        assert "stitching_type" in handler.settings
+        assert handler.settings["stitching_type"] == expected_xml_value
+
+    @patch("refred.reduction.global_reduction_settings_handler.GuiUtility")
+    def test_stitching_type_unknown_defaults_to_none(self, mock_gui_utility_cls):
+        """An unrecognized GUI stitching type maps to 'None' as a safe default."""
+        mock_gui_utility_cls.return_value.getStitchingType.return_value = "unknown_type"
+
+        parent = MagicMock()
+        handler = GlobalReductionSettingsHandler(parent=parent)
+
+        assert handler.settings["stitching_type"] == "None"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Description of work:
Continued work on efforts to move auto stitching into `lr_reduction`. This PR allows saving/loading of stitching configurations from the template.

An new checkbox `Normalize first angle` is added for when `Auto. Stitching` is enabled. This is required per changes in the previous work, and per CIS request

Check all that apply:

- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)

**References:**

- Links to IBM EWM items: [13786: [RefRed] Save and load reflectivity scale factors in the template file](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/13786)
- Links to related issues or pull requests:

## :warning:  Manual test for the reviewer

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
