### PR TITLE
Indicate when Data/Norm Run Load fails

### DIFF
--- a/src/refred/autopopulatemaintable/reduction_table_auto_fill.py
+++ b/src/refred/autopopulatemaintable/reduction_table_auto_fill.py
@@ -43,6 +43,10 @@ class ReductionTableAutoFill(object):
 
     def __init__(self, parent=None, list_of_run_from_input="", data_type_selected="data", reset_table=False):
         self.parent = parent
+        if data_type_selected != "data":
+            data_type_selected = "norm"
+        self.data_type_selected = data_type_selected
+        self.init_variable()
 
         if data_type_selected == "data":
             # add to norm box, previous loaded norm
@@ -63,12 +67,6 @@ class ReductionTableAutoFill(object):
             self.sorted_list_of_runs = []
             if not self.browsing_files_flag:
                 return
-
-        if data_type_selected != "data":
-            data_type_selected = "norm"
-        self.data_type_selected = data_type_selected
-
-        self.init_variable()
 
         self.reset_table = reset_table
 
@@ -126,11 +124,16 @@ class ReductionTableAutoFill(object):
         self.list_of_run_from_lconfig = []
         self.list_lrdata_sorted = None
         self.runs_found = 0
+        self.runs_processed = 0
         self.number_of_runs = 0
         self.filename_thread_array = None
         self.list_nexus_sorted = None
         self.list_nexus_loaded = None
         self.list_run_loaded = None
+        self.manual_runs_requested = []
+        self.manual_runs_requested_lookup = set()
+        self.manual_runs_not_found_lookup = set()
+        self.list_manual_runs_not_found = []
 
     def run(self):
         self.cleanup_workspaces()
@@ -196,14 +199,19 @@ class ReductionTableAutoFill(object):
         _list_of_runs = self.full_list_of_runs
         self.number_of_runs = len(_list_of_runs)
         self.runs_found = 0
+        self.runs_processed = 0
         self.init_filename_thread_array(len(_list_of_runs))
         for index, _run in enumerate(_list_of_runs):
             _thread = self.filename_thread_array[index]
             _thread.setup(self, _run, index)
             _thread.start()
 
-        while self.runs_found < self.number_of_runs:
+        while self.runs_processed < self.number_of_runs:
             time.sleep(0.5)
+
+        self.list_manual_runs_not_found = [
+            run for run in self.manual_runs_requested if run in self.manual_runs_not_found_lookup
+        ]
 
         if (self.runs_found > 0) or (self.browsing_files_flag):
             self.o_auto_fill_widgets_handler.step1()
@@ -227,11 +235,16 @@ class ReductionTableAutoFill(object):
     def retrieve_list_of_runs_from_nexus_metadata(self):
         _list_nxs = self.list_nxs
         _list_runs = []
+        _list_nxs_found = []
         for _nxs in _list_nxs:
+            if _nxs is None:
+                continue
             _run = get_run_number(_nxs)
             if _run is not None and nxs_has_required_properties(_nxs):
                 _list_runs.append(_run)
+                _list_nxs_found.append(_nxs)
 
+        self.list_nxs = _list_nxs_found
         self.full_list_of_runs = _list_runs
 
     def loading_runs(self):
@@ -339,7 +352,7 @@ class ReductionTableAutoFill(object):
         _list_full_file_name = []
         for i in range(sz):
             _filename_thread_array.append(LocateRunThread())
-            _list_full_file_name.append("")
+            _list_full_file_name.append(None)
         self.filename_thread_array = _filename_thread_array
         self.list_nxs = _list_full_file_name
 
@@ -347,6 +360,8 @@ class ReductionTableAutoFill(object):
         _raw_run_from_input = self.raw_run_from_input
         sequence_breaker = RunSequenceBreaker(_raw_run_from_input)
         self.list_of_run_from_input = sequence_breaker.final_list
+        self.manual_runs_requested = list(dict.fromkeys(self.list_of_run_from_input))
+        self.manual_runs_requested_lookup = set(self.manual_runs_requested)
 
     def retrieve_bigtable_list_data_loaded(self):
         parent = self.parent
@@ -371,6 +386,16 @@ class ReductionTableAutoFill(object):
         full_list_of_runs = self.full_list_of_runs
         full_list_without_duplicate = list(set(full_list_of_runs))
         self.full_list_of_runs = full_list_without_duplicate
+
+    def record_located_run(self, index, full_file_name):
+        self.list_nxs[index] = full_file_name
+        self.runs_found += 1
+        self.runs_processed += 1
+
+    def record_missing_run(self, run_number):
+        if run_number in self.manual_runs_requested_lookup:
+            self.manual_runs_not_found_lookup.add(run_number)
+        self.runs_processed += 1
 
     def check_minimum_requirements(self):
         _data_type_selected = self.data_type_selected

--- a/src/refred/background_tasks/locate_run.py
+++ b/src/refred/background_tasks/locate_run.py
@@ -15,11 +15,9 @@ class LocateRunThread(QtCore.QThread):  # type: ignore
         full_file_name = refred.nexus_utilities.find_nexus_full_path(self.run_number)
 
         if full_file_name and nxs_has_required_properties(full_file_name):
-            self.parent.list_nxs[self.index] = full_file_name
-            self.parent.runs_found += 1
+            self.parent.record_located_run(self.index, full_file_name)
         else:
-            self.parent.number_of_runs = self.parent.number_of_runs - 1
-            self.parent.list_nxs.pop(self.index)
+            self.parent.record_missing_run(self.run_number)
 
     def stop(self):
         # TODO: investigate why this was implemented this way and remove this method

--- a/src/refred/main.py
+++ b/src/refred/main.py
@@ -168,6 +168,8 @@ class MainGui(QtWidgets.QMainWindow):
         self.ui.reductionTable.setUI(self)
         MakeGuiConnections(parent=self)
         RetrieveUserConfiguration(parent=self)
+        self.ui.data_sequence_lineEdit.textEdited.connect(self.data_sequence_line_edit_edited)
+        self.ui.norm_sequence_lineEdit.textEdited.connect(self.norm_sequence_line_edit_edited)
 
         self.file_loaded_signal.connect(self.file_loaded)
         log_file = os.path.expanduser("~") + "/.refred.log"
@@ -511,38 +513,71 @@ class MainGui(QtWidgets.QMainWindow):
         self.data_sequence_event()
         self.norm_sequence_event()
 
+    def sequence_line_edit(self, data_type):
+        if data_type == "data":
+            return self.ui.data_sequence_lineEdit
+        return self.ui.norm_sequence_lineEdit
+
+    def clear_sequence_line_edit_feedback(self, data_type):
+        line_edit = self.sequence_line_edit(data_type)
+        line_edit.setStyleSheet("")
+
+    def reset_sequence_line_edit(self, data_type):
+        line_edit = self.sequence_line_edit(data_type)
+        self.clear_sequence_line_edit_feedback(data_type)
+        line_edit.setText("")
+
+    def display_sequence_line_edit_error(self, data_type, missing_runs):
+        line_edit = self.sequence_line_edit(data_type)
+        runs_not_located = ",".join([str(run) for run in missing_runs])
+        line_edit.setStyleSheet("color: red;")
+        line_edit.setText(f"Cannot locate {data_type} run(s): {runs_not_located}.")
+
+    def update_sequence_line_edit_after_autofill(self, data_type, auto_fill):
+        missing_runs = getattr(auto_fill, "list_manual_runs_not_found", [])
+        if missing_runs:
+            self.display_sequence_line_edit_error(data_type, missing_runs)
+            return
+        self.reset_sequence_line_edit(data_type)
+
+    def data_sequence_line_edit_edited(self, text):
+        self.clear_sequence_line_edit_feedback("data")
+
+    def norm_sequence_line_edit_edited(self, text):
+        self.clear_sequence_line_edit_feedback("norm")
+
     @config_file_has_been_modified
     def data_sequence_event(self, *args, **kwargs):
         str_data_input = self.ui.data_sequence_lineEdit.text()
-        ReductionTableAutoFill(
+        auto_fill = ReductionTableAutoFill(
             parent=self,
             list_of_run_from_input=str_data_input,
             data_type_selected="data",
         )
-        self.ui.data_sequence_lineEdit.setText("")
+        self.update_sequence_line_edit_after_autofill("data", auto_fill)
         self.norm_sequence_event()
 
     @config_file_has_been_modified
     def data_browse_button(self, *args, **kwargs):
         BrowsingRuns(parent=self, data_type="data")
         ReductionTableAutoFill(parent=self, list_of_run_from_input="", data_type_selected="data")
-        self.ui.data_sequence_lineEdit.setText("")
+        self.reset_sequence_line_edit("data")
 
     @config_file_has_been_modified
     def norm_sequence_event(self, *args, **kwargs):
         str_norm_input = self.ui.norm_sequence_lineEdit.text()
-        ReductionTableAutoFill(
+        auto_fill = ReductionTableAutoFill(
             parent=self,
             list_of_run_from_input=str_norm_input,
             data_type_selected="norm",
         )
-        self.ui.norm_sequence_lineEdit.setText("")
+        self.update_sequence_line_edit_after_autofill("norm", auto_fill)
 
     @config_file_has_been_modified
     def norm_browse_button(self, *args, **kwargs):
         BrowsingRuns(parent=self, data_type="norm")
         ReductionTableAutoFill(parent=self, list_of_run_from_input="", data_type_selected="norm")
-        self.ui.norm_sequence_lineEdit.setText("")
+        self.reset_sequence_line_edit("norm")
 
     # Menu buttons
     def action_new(self):

--- a/src/refred/main.py
+++ b/src/refred/main.py
@@ -510,8 +510,11 @@ class MainGui(QtWidgets.QMainWindow):
 
     @config_file_has_been_modified
     def data_norm_sequence_event(self, *args, **kwargs):
+        sender = self.sender()
+        if sender == self.ui.norm_sequence_lineEdit:
+            self.norm_sequence_event()
+            return
         self.data_sequence_event()
-        self.norm_sequence_event()
 
     def sequence_line_edit(self, data_type):
         if data_type == "data":

--- a/test/unit/refred/autopopulatemaintable/test_reduction_table_auto_fill.py
+++ b/test/unit/refred/autopopulatemaintable/test_reduction_table_auto_fill.py
@@ -1,10 +1,31 @@
 from unittest import mock
 
+import pytest
+
 from refred.autopopulatemaintable.reduction_table_auto_fill import ReductionTableAutoFill
 from refred.calculations.lr_data import LRData
 from refred.gui_handling.data_norm_spinboxes import DataSpinbox, NormSpinbox
 from refred.main import MainGui
 from refred.reduction_table_handling.reduction_table_check_box import ReductionTableCheckBox
+
+wait = 2000
+
+
+def _run_manual_sequence_event(window_main, data_type, run_input):
+    if data_type == "data":
+        line_edit = window_main.ui.data_sequence_lineEdit
+        event = window_main.data_sequence_event
+    else:
+        line_edit = window_main.ui.norm_sequence_lineEdit
+        event = window_main.norm_sequence_event
+
+    line_edit.setText(run_input)
+    event()
+    return line_edit
+
+
+def _prepare_norm_loading(window_main):
+    ReductionTableAutoFill(parent=window_main, list_of_run_from_input="188299", data_type_selected="data")
 
 
 @mock.patch("refred.calculations.locate_list_run.FileFinder.findRuns")
@@ -41,9 +62,95 @@ def test_reduction_table_auto_fill_two_runs(mock_file_finder_find_runs, file_fin
     window_main.norm_sequence_event()
 
     # verify that the background position of the first run (now in the second row in the table) is the same
-    run_data: LRData = window_main.big_table_data.reflectometry_data(0)
+    run_data = window_main.big_table_data.reflectometry_data(0)
     assert run_data.run_number == run_str_1
     assert run_data.back == [back_min, back_max]
-    norm_data: LRData = window_main.big_table_data.normalization_data(0)
+    norm_data = window_main.big_table_data.normalization_data(0)
     assert norm_data.run_number == norm_str_1
     assert norm_data.back == [back_min, back_max]
+
+
+@mock.patch("refred.calculations.locate_list_run.FileFinder.findRuns")
+@pytest.mark.parametrize(
+    ("data_type", "valid_run", "expected_message"),
+    [
+        ("data", "188299", "Cannot locate data run(s): 999999."),
+        ("norm", "188231", "Cannot locate norm run(s): 999999."),
+    ],
+)
+def test_manual_sequence_event_mixed_valid_invalid_runs(
+    mock_file_finder_find_runs, data_type, valid_run, expected_message, file_finder_find_runs, qtbot
+):
+    mock_file_finder_find_runs.side_effect = file_finder_find_runs
+
+    window_main = MainGui()
+    qtbot.addWidget(window_main)
+    if data_type == "norm":
+        _prepare_norm_loading(window_main)
+
+    line_edit = _run_manual_sequence_event(window_main, data_type, f"{valid_run},999999")
+    qtbot.wait(wait)
+
+    if data_type == "data":
+        loaded_data = window_main.big_table_data.reflectometry_data(0)
+    else:
+        loaded_data = window_main.big_table_data.normalization_data(0)
+    assert loaded_data is not None
+    assert loaded_data.run_number == valid_run
+    assert line_edit.text() == expected_message
+    assert "red" in line_edit.styleSheet()
+
+
+@mock.patch("refred.calculations.locate_list_run.FileFinder.findRuns")
+@pytest.mark.parametrize(
+    ("data_type", "valid_run"),
+    [
+        ("data", "188299"),
+        ("norm", "188231"),
+    ],
+)
+def test_manual_sequence_event_all_valid_runs_clear_line_edit(
+    mock_file_finder_find_runs, data_type, valid_run, file_finder_find_runs, qtbot
+):
+    mock_file_finder_find_runs.side_effect = file_finder_find_runs
+
+    window_main = MainGui()
+    qtbot.addWidget(window_main)
+    if data_type == "norm":
+        _prepare_norm_loading(window_main)
+
+    line_edit = _run_manual_sequence_event(window_main, data_type, valid_run)
+    qtbot.wait(wait)
+
+    assert line_edit.text() == ""
+    assert line_edit.styleSheet() == ""
+
+
+@mock.patch("refred.calculations.locate_list_run.FileFinder.findRuns")
+@pytest.mark.parametrize(
+    ("data_type", "expected_message"),
+    [
+        ("data", "Cannot locate data run(s): 999999."),
+        ("norm", "Cannot locate norm run(s): 999999."),
+    ],
+)
+def test_manual_sequence_event_all_invalid_runs_show_error(
+    mock_file_finder_find_runs, data_type, expected_message, file_finder_find_runs, qtbot
+):
+    mock_file_finder_find_runs.side_effect = file_finder_find_runs
+
+    window_main = MainGui()
+    qtbot.addWidget(window_main)
+    if data_type == "norm":
+        _prepare_norm_loading(window_main)
+
+    line_edit = _run_manual_sequence_event(window_main, data_type, "999999")
+    qtbot.wait(wait)
+
+    if data_type == "data":
+        loaded_data = window_main.big_table_data.reflectometry_data(0)
+    else:
+        loaded_data = window_main.big_table_data.normalization_data(0)
+    assert loaded_data is None
+    assert line_edit.text() == expected_message
+    assert "red" in line_edit.styleSheet()


### PR DESCRIPTION
## Description of work:
Currently when a data or norm run entered in the runs panel fails to be loaded, the failure is silent. CIS request it to be more visible to the user when this occurs.

This PR modifies the `LineEdit` with a red message "Cannot locate data/norm run(s): <run1>,<run2>,<etc>" on a failure.

Check all that apply:

- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)

**References:**

- Links to IBM EWM items: [14852: [RefRed] when a data or normalization run is unable to be loaded, it should be very obvious to the user](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14852)
- Links to related issues or pull requests:

## :warning:  Manual test for the reviewer

([instructions to set up the environment](https://github.com/neutrons/RefRed/blob/next/docs/developer/testing.rst#running-manual-tests-in-a-pull-request))

# Check list for the reviewer

- [ ] best software practices
  - [ ] clearly named variables (better to be verbose in variable names)
  - [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
